### PR TITLE
Add test for Gallery block for "Other Apps" option when uploading media

### DIFF
--- a/test-cases/gutenberg/gallery.md
+++ b/test-cases/gutenberg/gallery.md
@@ -252,3 +252,26 @@ Gallery block should allow images to be rearranged in the gallery.
     * Adding even and uneven image counts and rearranging the last image
     * Leaving the editor and coming back in
     * Validate order is reflected on the Web after saving
+    
+    
+--------------------------------------------------------------------------------
+    
+##### TC013
+
+### Choose from Other Apps (iOS Files App)
+
+Gallery block should allow uploading images from the iOS Files app.
+
+**Steps:**
+
+* Add a gallery block and tap "Add Media"
+* Select "Other Apps" option
+* Select multiple images from the Files app
+
+**Expected behavior:**
+
+* Gallery should show all images being uploaded as dimmed
+* Progress bars should be displayed indicating the upload progress
+* After each image upload has completed:
+  * Image should not be dim
+  * Image url scheme should be `https://` (not `file:///`) in HTML mode


### PR DESCRIPTION
## Description

Proposing adding a test for the Gallery block that covers the scenario where the user chooses the "Other Apps" option when uploading media.

## Additional Info

Testing this scenario led me to uncover this bug on iOS: https://github.com/wordpress-mobile/gutenberg-mobile/issues/2040