### PR TITLE
Add style merge and strikethrough issues

### DIFF
--- a/test-cases/gutenberg/writing-flow/rich-text-formatting.md
+++ b/test-cases/gutenberg/writing-flow/rich-text-formatting.md
@@ -14,7 +14,7 @@ Have a rich-text based component with content (Paragraph, Heading, Quote, Media 
 - Press strikethrough button and write strikethrough text.
 
 **Known Issues**
-- Strikethrough formatting uses a different tag depending on how it is applied and strikethrough button does not always reflect state: [#729](https://github.com/wordpress-mobile/gutenberg-mobile/issues/729).
+- **[Android]** Strikethrough formatting uses a different tag depending on how it is applied and strikethrough button does not always reflect state: [#729](https://github.com/wordpress-mobile/gutenberg-mobile/issues/729).
 
 
 ##### TC002
@@ -74,7 +74,6 @@ Have a rich-text based component with content (Paragraph, Heading, Quote, Media 
 - On a rich-text based component, add bold, italic, strikethrough and link formatted text, both combined and on different words.
 Move the cursor around
 - Check that the proper format buttons get selected when the cursor get under a formatted word.
-
 
 
 

--- a/test-cases/gutenberg/writing-flow/rich-text-formatting.md
+++ b/test-cases/gutenberg/writing-flow/rich-text-formatting.md
@@ -7,11 +7,14 @@ Have a rich-text based component with content (Paragraph, Heading, Quote, Media 
 
 ##### TC001
 
-**Bold, Italic, strikethrough buttons **
+**Bold, Italic, strikethrough buttons**
 
 - Press the Bold button and write a bold word.
 - Press the Italic button and write an italic word.
 - Press strikethrough button and write strikethrough text.
+
+**Known Issues**
+- Strikethrough formatting uses a different tag depending on how it is applied and strikethrough button does not always reflect state: [#729](https://github.com/wordpress-mobile/gutenberg-mobile/issues/729).
 
 
 ##### TC002

--- a/test-cases/gutenberg/writing-flow/splitting-merging.md
+++ b/test-cases/gutenberg/writing-flow/splitting-merging.md
@@ -40,6 +40,9 @@ Start from an empty post.
 - Delete all those words until the blocks merge.
 - Check that the blocks were merged.
 
+**Known Issues**
+- Does not merge on Android after deleting either styled text or a selection containing multiple charaacters (instead of single characters): [#1873](https://github.com/wordpress-mobile/gutenberg-mobile/issues/1873#issuecomment-608070758).
+
 
 ##### TC004
 

--- a/test-cases/gutenberg/writing-flow/splitting-merging.md
+++ b/test-cases/gutenberg/writing-flow/splitting-merging.md
@@ -41,7 +41,7 @@ Start from an empty post.
 - Check that the blocks were merged.
 
 **Known Issues**
-- Does not merge on Android after deleting either styled text or a selection containing multiple charaacters (instead of single characters): [#1873](https://github.com/wordpress-mobile/gutenberg-mobile/issues/1873#issuecomment-608070758).
+- **[Android]** Does not merge on Android after deleting either styled text or a selection containing multiple charaacters (instead of single characters): [#1873](https://github.com/wordpress-mobile/gutenberg-mobile/issues/1873#issuecomment-608070758).
 
 
 ##### TC004


### PR DESCRIPTION
Adding references to issues found when running test cases. Originally reported in [this comment](https://github.com/wordpress-mobile/WordPress-Android/pull/11580#issuecomment-608008382).