### PR TITLE
Update multiline component test cases for captions

### DIFF
--- a/test-cases/gutenberg/writing-flow/multiline-components.md
+++ b/test-cases/gutenberg/writing-flow/multiline-components.md
@@ -24,4 +24,4 @@ Test the next steps on:
   - *Preformatted*: `<br>` ending lines.
   - *Code*: (Invisible `\n`) new line character.
   - *Pullquote*: `<p>` tags per non-wrapping "line"
-  - *Pullquote citation*: should _not_ be multiline (see Knwon Issues)
+  - *Pullquote citation*: should _not_ be multiline (see Known Issues)

--- a/test-cases/gutenberg/writing-flow/multiline-components.md
+++ b/test-cases/gutenberg/writing-flow/multiline-components.md
@@ -10,18 +10,18 @@ Test the next steps on:
 
 ##### TC001
 
+**Known Issues**
+- On captions, pressent Enter at the end of a caption splits the block, but pressing enter in the middle of a caption's text does nothing. Discussed in [this comment](https://github.com/WordPress/gutenberg/pull/22928#issuecomment-640879690).
+
 **New line on multiline components**
 
 - Start typing and press enter to create a new line.
 - The new line should be created, without splitting the block.
 - Check on HTML mode that the resulting HTML code is correct:
   - *Quote*: `<p>` tags per paragraph.
-  - *Quote citation*: `<br>` ending lines.
+  - *Quote citation*: should _not_ be multiline (see Known Issues)
   - *Verse*: `<br>` ending lines.
   - *Preformatted*: `<br>` ending lines.
   - *Code*: (Invisible `\n`) new line character.
   - *Pullquote*: `<p>` tags per non-wrapping "line"
-  - *Pullquote citation*: `<br>` between non-wrapping "lines"
-
-**Known Issues**
-- **[Android]** Multiline captions are not working as expected. [#1651](https://github.com/wordpress-mobile/gutenberg-mobile/issues/1651)
+  - *Pullquote citation*: should _not_ be multiline (see Knwon Issues)


### PR DESCRIPTION
Updating the test cases for multiline components now that captions have been updated to split.