### PR TITLE
Add test case for unsupported block editor

### DIFF
--- a/test-cases/gutenberg/unsupported-block-editing.md
+++ b/test-cases/gutenberg/unsupported-block-editing.md
@@ -12,7 +12,7 @@
     ```
     <!-- wp:jetpack/markdown {\"source\":\"Hello\\nWorld\"} -->\n<div class=\"wp-block-jetpack-markdown\"><p>Hello\nWorld</p>\n</div>\n<!-- /wp:jetpack/markdown -->
     ```
-2. Switch back to visual Visual mode if needed
+2. Switch back to Visual mode if needed
 3. Expect to see the block rendered as a placeholder with the text "Unsupported"
 4. Tap the `(?)` icon and expect the option to edit the block in a web browser to be shown
 5. Tap the edit in a web browser and expect the block to be shown, ready to edit, in a new screen
@@ -48,4 +48,3 @@ This feature is disabled for Jetpack connected sites.
 ### Self-hosted sites are supported
 
 Repeat steps from TC001 using a post on a .org site (self-hosted)
-

--- a/test-cases/gutenberg/unsupported-block-editing.md
+++ b/test-cases/gutenberg/unsupported-block-editing.md
@@ -25,6 +25,8 @@
 
 ### Discarded edits are not persisted
 
-1. Repeat steps 1 to 6 above
-2. Tap the Cancel button and expect to be taken back to the block editor
-3. Publish the post and verify it **does not** contain the edited block content
+1. Repeat steps 1 to 5 above
+2. Edit the block content (e.g. update its text)
+3. Tap the Cancel button and expect to be taken back to the block editor
+4. Expect the Update button to be greyed-out
+5. Inspect the HTML content of the post and expect it to **not** contain any of the changes

--- a/test-cases/gutenberg/unsupported-block-editing.md
+++ b/test-cases/gutenberg/unsupported-block-editing.md
@@ -23,10 +23,13 @@
 
 ##### TC002
 
+**Known Issues**
+-  **[Android]** The update button is not greyed-out when changes are discarded
+
 ### Discarded edits are not persisted
 
 1. Repeat steps 1 to 5 above
 2. Edit the block content (e.g. update its text)
-3. Tap the Cancel button and expect to be taken back to the block editor
+3. Tap the Cancel button to discard changes and expect to be taken back to the block editor
 4. Expect the Update button to be greyed-out
 5. Inspect the HTML content of the post and expect it to **not** contain any of the changes

--- a/test-cases/gutenberg/unsupported-block-editing.md
+++ b/test-cases/gutenberg/unsupported-block-editing.md
@@ -33,3 +33,19 @@
 3. Tap the Cancel button to discard changes and expect to be taken back to the block editor
 4. Expect the Update button to be greyed-out
 5. Inspect the HTML content of the post and expect it to **not** contain any of the changes
+
+##### TC003
+
+### WP.com Business (Atomic) sites are supported
+
+Repeat steps from TC001 using a post on a WP.com site with a Business Plan (i.e. Atomic site)
+
+##### TC004
+
+**Known Issues**
+This feature is disabled for Jetpack connected sites.
+
+### Self-hosted sites are supported
+
+Repeat steps from TC001 using a post on a .org site (self-hosted)
+

--- a/test-cases/gutenberg/unsupported-block-editing.md
+++ b/test-cases/gutenberg/unsupported-block-editing.md
@@ -4,19 +4,27 @@
 
 ##### TC001
 
-### Editing changes are persisted 
+### New edits are persisted 
 
--   Add a block that's not yet supported on mobile (e.g. the Jetpack Markdown `jetpack/markdown` block) — this can be done by switching to HTML mode and pasting in the raw content
+1. Add a block that's not yet supported on mobile (e.g. the Jetpack Markdown `jetpack/markdown` block) — this can be done by switching to HTML mode and pasting in the raw content
 
     Example HTML:
     ```
     <!-- wp:jetpack/markdown {\"source\":\"Hello\\nWorld\"} -->\n<div class=\"wp-block-jetpack-markdown\"><p>Hello\nWorld</p>\n</div>\n<!-- /wp:jetpack/markdown -->
     ```
--   Switch back to visual Visual mode if needed
--   Expect to see the block rendered as a placeholder with the text "Unsupported"
--   Tap the `(?)` icon and expect the option to edit the block in a web browser to be shown
--   Tap the edit in a web browser and expect the block to be shown, ready to edit, in a new screen
--   Edit the block content (e.g. update its text)
--   Tap the Continue button and expect to be taken back to the block editor
--   Publish the post and verify it contains the edited block content
+2. Switch back to visual Visual mode if needed
+3. Expect to see the block rendered as a placeholder with the text "Unsupported"
+4. Tap the `(?)` icon and expect the option to edit the block in a web browser to be shown
+5. Tap the edit in a web browser and expect the block to be shown, ready to edit, in a new screen
+6. Edit the block content (e.g. update its text)
+7. Tap the Continue button and expect to be taken back to the block editor
+8. Publish the post and verify it contains the edited block content
 
+
+##### TC002
+
+### Discarded edits are not persisted
+
+1. Repeat steps 1 to 6 above
+2. Tap the Cancel button and expect to be taken back to the block editor
+3. Publish the post and verify it **does not** contain the edited block content

--- a/test-cases/gutenberg/unsupported-block-editing.md
+++ b/test-cases/gutenberg/unsupported-block-editing.md
@@ -1,0 +1,22 @@
+# Unsupported Block Editing - Test Cases
+
+--------------------------------------------------------------------------------
+
+##### TC001
+
+### Editing changes are persisted 
+
+-   Add a block that's not yet supported on mobile (e.g. the Jetpack Markdown `jetpack/markdown` block) — this can be done by switching to HTML mode and pasting in the raw content
+
+    Example HTML:
+    ```
+    <!-- wp:jetpack/markdown {\"source\":\"Hello\\nWorld\"} -->\n<div class=\"wp-block-jetpack-markdown\"><p>Hello\nWorld</p>\n</div>\n<!-- /wp:jetpack/markdown -->
+    ```
+-   Switch back to visual Visual mode if needed
+-   Expect to see the block rendered as a placeholder with the text "Unsupported"
+-   Tap the `(?)` icon and expect the option to edit the block in a web browser to be shown
+-   Tap the edit in a web browser and expect the block to be shown, ready to edit, in a new screen
+-   Edit the block content (e.g. update its text)
+-   Tap the Continue button and expect to be taken back to the block editor
+-   Publish the post and verify it contains the edited block content
+


### PR DESCRIPTION
Test cases for the [unsupported block project](https://github.com/wordpress-mobile/gutenberg-mobile/issues/2358)