### PR TITLE
Update button theme support test and add deprecation note in the spacer

### DIFF
--- a/test-cases/gutenberg/buttons.md
+++ b/test-cases/gutenberg/buttons.md
@@ -253,7 +253,7 @@
 -   Choose a theme color from the **palette* (among the predefined ones)
 -   Save the post
 -   Open the same post on mobile app
--   Expect `Button` with gray background color and white text color
+-   Expect `Button` with selected background color and selected text color
 
 --------------------------------------------------------------------------------
 

--- a/test-cases/gutenberg/spacer.md
+++ b/test-cases/gutenberg/spacer.md
@@ -76,7 +76,7 @@ Expected look:
 ### Settings: Height range extends if Spacer comes from the web is higher than 500px
 <details>
  <summary>Deprecation note</summary>
-  Setting height bigger than 500px is no longer available on the web, however, we still need to do this test because of backward compatibility. In order to test it, please use the code editor mode to change the height of the spacer.
+  Setting height bigger than 500px is no longer available on the web, however, we still need to do this test because of backward compatibility. In order to test it, please use the html editor mode to change the height of the spacer.
 </details>
 
 -   Add a `Spacer` block via web version

--- a/test-cases/gutenberg/spacer.md
+++ b/test-cases/gutenberg/spacer.md
@@ -74,6 +74,10 @@ Expected look:
 ##### TC005
 
 ### Settings: Height range extends if Spacer comes from the web is higher than 500px
+<details>
+ <summary>Deprecation note</summary>
+  Setting height bigger than 500px is no longer available on the web, however, we still need to do this test because of backward compatibility. In order to test it, please use the code editor mode to change the height of the spacer.
+</details>
 
 -   Add a `Spacer` block via web version
 -   Set `Spacer` height to more than `500px` (in given example `1600px`)


### PR DESCRIPTION
In this PR i changed the test that is related to supporting theme colors in the button block. We already support theming so we should expect selected colors instead of gray and white.

I also added a `Deprecation note` in the spacer block - `Settings: Height range extends if Spacer comes from the web is higher than 500px`. I don't know when it was introduced but i can not set more than 500px on the web as well. I think it is still worth testing but in order to do that, the height has to be changed in the code editor mode.