### PR TITLE
Update columns.md

### DIFF
--- a/test-cases/gutenberg/columns.md
+++ b/test-cases/gutenberg/columns.md
@@ -186,7 +186,7 @@ Expected look:
 - Create some nested structure adding more `Column` and nesting `Columns`
 - Expect all `Column` is distributed in row depending on available space for container:
   - below `480px` then expect 1 `Column` in row to be rendered
-  - between `480px` and `768px` then expect  2 `Column` in row to be rendered
+  - between `480px` and `768px` then expect 3 `Column` in row to be rendered
   - more than `768px` then expect as much `Column` as possible in row to be rendered
 - Expect space around blocks do not bounce when changing selection (exception is the trasition of the selected block connected with making space for FloatingToolbar)
 - Expect no weird/unexpected extra free space around blocks


### PR DESCRIPTION
Update Columns - Appearance in horizontal device position (horizontal layout) as this was changed to support 3 columns

This was recently changed by @antonis to default to 3 columns in landscape instead of 2 

https://github.com/wordpress-mobile/gutenberg-mobile/issues/2384