### PR TITLE
Clean up writing flow formatting issue

### DIFF
--- a/test-cases/gutenberg/writing-flow/readme.md
+++ b/test-cases/gutenberg/writing-flow/readme.md
@@ -4,22 +4,22 @@
 - [ ] TC001 - Paste formatted text copied from website
 - [ ] TC001 - Multiline components
 #### Rich Text Format
-  - [ ] TC001 - Bold, Italic, strikethrough buttons
-  - [ ] TC002 - Alignment buttons
-  - [ ] TC003 - Alignment Split
-  - [ ] TC004 - Link button works without selection
-  - [ ] TC005 - Link button works with a selected word
-  - [ ] TC006 - Adding a link from a copied URL
-  - [ ] TC007 - Test format detection under the cursor
-  - [ ] TC008 - Test formatting doesn't remove leading or trailing whitespace
+- [ ] TC001 - Bold, Italic, strikethrough buttons
+- [ ] TC002 - Alignment buttons
+- [ ] TC003 - Alignment Split
+- [ ] TC004 - Link button works without selection
+- [ ] TC005 - Link button works with a selected word
+- [ ] TC006 - Adding a link from a copied URL
+- [ ] TC007 - Test format detection under the cursor
+- [ ] TC008 - Test formatting doesn't remove leading or trailing whitespace
 ##### Splitting and merging
-  - [ ] TC001 - Merge after writing
-  - [ ] TC002 - Merge after selection
-  - [ ] TC003 - Merge after deleting text
-  - [ ] TC004 - Merge after deleting all
-  - [ ] TC005 - Merge multiple blocks
-  - [ ] TC006 - Splitting/merge list block
+- [ ] TC001 - Merge after writing
+- [ ] TC002 - Merge after selection
+- [ ] TC003 - Merge after deleting text
+- [ ] TC004 - Merge after deleting all
+- [ ] TC005 - Merge multiple blocks
+- [ ] TC006 - Splitting/merge list block
 #### Undo / Redo - Test Cases
-  - [ ] TC001 - Undo/redo block actions
-  - [ ] TC002 - Undo/redo text
-  - [ ] TC003 - Undo/redo text format
+- [ ] TC001 - Undo/redo block actions
+- [ ] TC002 - Undo/redo text
+- [ ] TC003 - Undo/redo text format


### PR DESCRIPTION
This just removes the unnecessary nesting from the list, so it can be easily copy/pasted to GitHub without having to then fix the indentation.