### PR TITLE
Add note regarding UBE and older WP.com accounts

### DIFF
--- a/test-cases/gutenberg/unsupported-block-editing.md
+++ b/test-cases/gutenberg/unsupported-block-editing.md
@@ -74,6 +74,9 @@ A WP.com Atomic site (i.e. a WP.com site with a Business plan) with the **Classi
 
 ##### TC005
 
+**Known Issues**
+- A Jetpack-site recently connected to a WPCom account older than December 2018 won’t display the option to open the Unsupported Block Editor. (p9ugOq-Zz-p2#comment-2626)
+
 #### Precondition
 
 For this test, you need a self-hosted site with the Jetpack plugin installed, activated and connected to a WP.com account. Here are the steps for creating this if needed:

--- a/test-cases/gutenberg/unsupported-block-editing.md
+++ b/test-cases/gutenberg/unsupported-block-editing.md
@@ -75,7 +75,7 @@ A WP.com Atomic site (i.e. a WP.com site with a Business plan) with the **Classi
 ##### TC005
 
 **Known Issues**
-- A Jetpack-site recently connected to a WPCom account older than December 2018 won’t display the option to open the Unsupported Block Editor. (p9ugOq-Zz-p2#comment-2626)
+- A Jetpack-site recently connected to a WPCom account older than December 2018 won’t display the option to open the Unsupported Block Editor. ([wordpress-mobile/gutenberg-mobile#3425](https://github.com/wordpress-mobile/gutenberg-mobile/issues/3425))
 
 #### Precondition
 


### PR DESCRIPTION
There is a known issue that a Jetpack-site recently connected to a WPCom account older than December 2018 won’t display the option to open the Unsupported Block Editor.