### PR TITLE
Update Unsupported Block Editor known issues

### DIFF
--- a/test-cases/gutenberg/unsupported-block-editing.md
+++ b/test-cases/gutenberg/unsupported-block-editing.md
@@ -10,7 +10,7 @@ A WP.com Simple site (i.e. not an Atomic site). Any free WP.com site should suff
 
 ### User can edit unsupported blocks on Simple WP.com sites
 
-1. On the site described above, add a post, then add a block that's not yet supported on mobile (e.g. Jetpack Markdown at time of writing)
+1. On the site described above, add a post, then add a block that's not yet supported on mobile
 2. Log into the WordPress mobile app using the site's WP.com account
 3. Open the post and expect to see the block rendered as a placeholder with the text "Unsupported"
 4. Tap the `(?)` icon and expect the option to edit the block in a web browser to be shown
@@ -36,7 +36,7 @@ A WP.com Simple site (i.e. not an Atomic site). Any free WP.com site should suff
 ##### TC003
 
 **Known Issues**
--  **[iOS and Android]** [Editing unsupported blocks is not enabled on sites accessed via older WP.com accounts](https://github.com/wordpress-mobile/gutenberg-mobile/issues/3425)
+-  **[Android]** [Editing unsupported blocks is not enabled on sites accessed via older WP.com accounts](https://github.com/wordpress-mobile/gutenberg-mobile/issues/3425)
 
 #### Precondition
 
@@ -48,12 +48,12 @@ A WP.com Atomic site (i.e. a WP.com site with a Business plan) with the **Gutenb
 
 ### Editing unsupported blocks is allowed on Gutenberg-enabled Atomic sites
 
-1. On the site described above, add a post, then add a block that's not yet supported on mobile (e.g. Jetpack Markdown at time of writing)
+1. On the site described above, add a post, then add a block that's not yet supported on mobile
 2. Log into the WordPress mobile app using the site's WP.com account
 3. Open the post and expect to see the block rendered as a placeholder with the text "Unsupported"
 4. Tap the `(?)` icon and expect the option to edit the block in a web browser to be shown
 5. Tap the edit in a web browser button and expect the block to be shown, ready to edit, on a new screen
-6. Edit the block content (e.g. update its caption)
+6. Edit the block content
 7. Tap the Continue button and expect to be taken back to the block editor
 8. Publish the post and verify it contains the edits
 
@@ -61,7 +61,7 @@ A WP.com Atomic site (i.e. a WP.com site with a Business plan) with the **Gutenb
 ##### TC004
 
 **Known Issues**
--  **[iOS and Android]** [Editing unsupported blocks is not enabled on sites accessed via older WP.com accounts](https://github.com/wordpress-mobile/gutenberg-mobile/issues/3425)
+-  **[Android]** [Editing unsupported blocks is not enabled on sites accessed via older WP.com accounts](https://github.com/wordpress-mobile/gutenberg-mobile/issues/3425)
 
 #### Precondition
 
@@ -77,13 +77,13 @@ A WP.com Atomic site (i.e. a WP.com site with a Business plan) with the **Classi
 1. On the site described above, add a post, then add a block that's not yet supported on mobile (e.g. Jetpack Markdown at time of writing)
 2. Log into the WordPress mobile app using the site's WP.com account
 3. Open the post and expect to see the block rendered as a placeholder with the text "Unsupported"
-4. Tap the `(?)` icon and expect to NOT see an option to edit the block in a web browser
+4. Tap the `(?)` icon and expect the web view to load before showing a message prompting users to ensure the block editor is enabled on their site.
 
 
 ##### TC005
 
 **Known Issues**
-- A Jetpack-site recently connected to a WPCom account older than December 2018 won’t display the option to open the Unsupported Block Editor. ([wordpress-mobile/gutenberg-mobile#3425](https://github.com/wordpress-mobile/gutenberg-mobile/issues/3425))
+-  **[Android]** [Editing unsupported blocks is not enabled on sites accessed via older WP.com accounts](https://github.com/wordpress-mobile/gutenberg-mobile/issues/3425)
 
 #### Precondition
 
@@ -95,7 +95,7 @@ For this test, you need a self-hosted site with the Jetpack plugin installed, ac
 
 ### Editing unsupported blocks is enabled on self-hosted sites accessed via Jetpack
 
-1. On the site described above, add a post, then add a block that's not yet supported on mobile (e.g. Jetpack Markdown at time of writing) via the site's WP Admin web interface
+1. On the site described above, add a post, then add a block that's not yet supported on mobile via the site's WP Admin web interface
 2. Log into the WordPress mobile app using the WP.com account that was used to connect Jetpack to the self-hosted site
 3. Open the post and expect to see the unsupported block rendered as a placeholder with the text "Unsupported"
 4. Tap the `(?)` icon and expect to see an option to enable `Login with WordPress.com`.
@@ -104,7 +104,7 @@ For this test, you need a self-hosted site with the Jetpack plugin installed, ac
 5. Expect the option to edit the block in a web browser to be shown
 6. Tap the edit in a web browser button and expect a web view requesting to `Login with WordPress.com`.
 7. Tap on said option and expect the block to be shown, ready to edit, on a new screen
-7. Edit the block content (e.g. update its caption)
+7. Edit the block content
 8. Tap the Continue button and expect to be taken back to the block editor
 9. Publish the post and verify it contains the edits
 
@@ -122,7 +122,7 @@ For this test, you need a self-hosted site with its own login credentials (we're
 
 ### Editing unsupported blocks is disallowed on self-hosted sites accessed via their own username and password
 
-1. On the site described above, add a post, then add a block that's not yet supported on mobile (e.g. RSS at time of writing) via the site's WP Admin web interface
+1. On the site described above, add a post, then add a block that's not yet supported on mobile via the site's WP Admin web interface
 2. Log into the WordPress mobile app by adding the site address and subsequently authenticating with the site username and password
 3. Open the post and expect to see the unsupported block rendered as a placeholder with the text "Unsupported"
-4. Tap the `(?)` icon and expect to NOT see an option to edit the block in a web browser
+4. Tap the `(?)` icon and expect to **not** see an option to edit the block in a web browser

--- a/test-cases/gutenberg/unsupported-block-editing.md
+++ b/test-cases/gutenberg/unsupported-block-editing.md
@@ -61,7 +61,7 @@ A WP.com Atomic site (i.e. a WP.com site with a Business plan) with the **Gutenb
 ##### TC004
 
 **Known Issues**
--  **[Android]** [Editing unsupported blocks is not enabled on sites accessed via older WP.com accounts](https://github.com/wordpress-mobile/gutenberg-mobile/issues/3425)
+- [Editing unsupported blocks is not enabled on sites accessed via older WP.com accounts](https://github.com/wordpress-mobile/gutenberg-mobile/issues/3425)
 
 #### Precondition
 
@@ -83,7 +83,7 @@ A WP.com Atomic site (i.e. a WP.com site with a Business plan) with the **Classi
 ##### TC005
 
 **Known Issues**
--  **[Android]** [Editing unsupported blocks is not enabled on sites accessed via older WP.com accounts](https://github.com/wordpress-mobile/gutenberg-mobile/issues/3425)
+- [Editing unsupported blocks is not enabled on sites accessed via older WP.com accounts](https://github.com/wordpress-mobile/gutenberg-mobile/issues/3425)
 
 #### Precondition
 

--- a/test-cases/gutenberg/unsupported-block-editing.md
+++ b/test-cases/gutenberg/unsupported-block-editing.md
@@ -15,7 +15,7 @@ A WP.com Simple site (i.e. not an Atomic site). Any free WP.com site should suff
 3. Open the post and expect to see the block rendered as a placeholder with the text "Unsupported"
 4. Tap the `(?)` icon and expect the option to edit the block in a web browser to be shown
 5. Tap the edit in a web browser button and expect the block to be shown, ready to edit, on a new screen
-6. Edit the block content (e.g. update its caption)
+6. Edit the block content
 7. Tap the Continue button and expect to be taken back to the block editor
 8. Publish the post and verify it contains the edits
 

--- a/test-cases/gutenberg/unsupported-block-editing.md
+++ b/test-cases/gutenberg/unsupported-block-editing.md
@@ -43,7 +43,7 @@ A WP.com Simple site (i.e. not an Atomic site). Any free WP.com site should suff
 A WP.com Atomic site (i.e. a WP.com site with a Business plan) with the **Gutenberg Editor** set as the default. Here are the steps for creating this if necessary:
 
 1. Find a site with a Business plan or higher
-2. Find an account created in 2019 or later (account age is found under https://wordpress.com/me/account), otherwise the known issue listed above will break the Unsupported Block Editor.
+2. Find an account created in 2019 or later (account age is found under https://wordpress.com/me/account), otherwise the known issue listed above will break the Unsupported Block Editor
 3. In Calypso choose your site and go to Tools | Plugins | Installed Plugins — ensure the Classic Editor plugin is **not** installed (or if it is installed, make sure it is not the default editor in the plugin settings)
 
 ### Editing unsupported blocks is allowed on Gutenberg-enabled Atomic sites
@@ -68,7 +68,7 @@ A WP.com Atomic site (i.e. a WP.com site with a Business plan) with the **Gutenb
 A WP.com Atomic site (i.e. a WP.com site with a Business plan) with the **Classic editor** set as the default. Here are the steps for creating this if necessary:
 
 1. Find a site with a Business plan or higher
-2. Find an account created in 2019 or later (account age is found under https://wordpress.com/me/account), otherwise the known issue listed above will break the Unsupported Block Editor.
+2. Find an account created in 2019 or later (account age is found under https://wordpress.com/me/account), otherwise the known issue listed above will break the Unsupported Block Editor
 3. Install and activate the Classic Editor plugin
 4. In Calypso choose your site and go to Tools | Plugins | Installed Plugins, then tap Settings under the Classic Editor plugin and set **Default editor for all users** to **Classic Editor**
 
@@ -77,7 +77,7 @@ A WP.com Atomic site (i.e. a WP.com site with a Business plan) with the **Classi
 1. On the site described above, add a post, then add a block that's not yet supported on mobile
 2. Log into the WordPress mobile app using the site's WP.com account
 3. Open the post and expect to see the block rendered as a placeholder with the text "Unsupported"
-4. Tap the `(?)` icon and expect the web view to load before showing a message prompting users to ensure the block editor is enabled on their site.
+4. Tap the `(?)` icon and expect to **not** see an option to edit the block in a web browser
 
 
 ##### TC005
@@ -98,11 +98,11 @@ For this test, you need a self-hosted site with the Jetpack plugin installed, ac
 1. On the site described above, add a post, then add a block that's not yet supported on mobile via the site's WP Admin web interface
 2. Log into the WordPress mobile app using the WP.com account that was used to connect Jetpack to the self-hosted site
 3. Open the post and expect to see the unsupported block rendered as a placeholder with the text "Unsupported"
-4. Tap the `(?)` icon and expect to see an option to enable `Login with WordPress.com`.
-5. Tap on that option, and enable `Login with WordPress.com` on the screen presented.
-4. Go back and tap the `(?)` icon.
+4. Tap the `(?)` icon and expect to see an option to enable `Login with WordPress.com`
+5. Tap on that option, and enable `Login with WordPress.com` on the screen presented
+4. Go back and tap the `(?)` icon
 5. Expect the option to edit the block in a web browser to be shown
-6. Tap the edit in a web browser button and expect a web view requesting to `Login with WordPress.com`.
+6. Tap the edit in a web browser button and expect a web view requesting to `Login with WordPress.com`
 7. Tap on said option and expect the block to be shown, ready to edit, on a new screen
 7. Edit the block content
 8. Tap the Continue button and expect to be taken back to the block editor

--- a/test-cases/gutenberg/unsupported-block-editing.md
+++ b/test-cases/gutenberg/unsupported-block-editing.md
@@ -36,7 +36,7 @@ A WP.com Simple site (i.e. not an Atomic site). Any free WP.com site should suff
 ##### TC003
 
 **Known Issues**
--  **[Android]** [Editing unsupported blocks is not enabled on sites accessed via older WP.com accounts](https://github.com/wordpress-mobile/gutenberg-mobile/issues/3425)
+- [Editing unsupported blocks is not enabled on sites accessed via older WP.com accounts](https://github.com/wordpress-mobile/gutenberg-mobile/issues/3425)
 
 #### Precondition
 

--- a/test-cases/gutenberg/unsupported-block-editing.md
+++ b/test-cases/gutenberg/unsupported-block-editing.md
@@ -74,7 +74,7 @@ A WP.com Atomic site (i.e. a WP.com site with a Business plan) with the **Classi
 
 ### Editing unsupported blocks is disallowed on Classic-enabled Atomic sites
 
-1. On the site described above, add a post, then add a block that's not yet supported on mobile (e.g. Jetpack Markdown at time of writing)
+1. On the site described above, add a post, then add a block that's not yet supported on mobile
 2. Log into the WordPress mobile app using the site's WP.com account
 3. Open the post and expect to see the block rendered as a placeholder with the text "Unsupported"
 4. Tap the `(?)` icon and expect the web view to load before showing a message prompting users to ensure the block editor is enabled on their site.

--- a/test-cases/gutenberg/unsupported-block-editing.md
+++ b/test-cases/gutenberg/unsupported-block-editing.md
@@ -10,7 +10,7 @@ A WP.com Simple site (i.e. not an Atomic site). Any free WP.com site should suff
 
 ### User can edit unsupported blocks on Simple WP.com sites
 
-1. On the site described above, add a post, then add a block that's not yet supported on mobile (e.g. Audio at time of writing)
+1. On the site described above, add a post, then add a block that's not yet supported on mobile (e.g. Jetpack Markdown at time of writing)
 2. Log into the WordPress mobile app using the site's WP.com account
 3. Open the post and expect to see the block rendered as a placeholder with the text "Unsupported"
 4. Tap the `(?)` icon and expect the option to edit the block in a web browser to be shown
@@ -35,16 +35,20 @@ A WP.com Simple site (i.e. not an Atomic site). Any free WP.com site should suff
 
 ##### TC003
 
+**Known Issues**
+-  **[iOS and Android]** [Editing unsupported blocks is not enabled on sites accessed via older WP.com accounts](https://github.com/wordpress-mobile/gutenberg-mobile/issues/3425)
+
 #### Precondition
 
 A WP.com Atomic site (i.e. a WP.com site with a Business plan) with the **Gutenberg Editor** set as the default. Here are the steps for creating this if necessary:
 
 1. Find a site with a Business plan or higher
-2. In Calypso choose your site and go to Tools | Plugins | Installed Plugins — ensure the Classic Editor plugin is **not** installed (or if it is installed, make sure it is not the default editor in the plugin settings)
+2. Find an account created in 2019 or later (account age is found under https://wordpress.com/me/account), otherwise the known issue listed above will break the Unsupported Block Editor.
+3. In Calypso choose your site and go to Tools | Plugins | Installed Plugins — ensure the Classic Editor plugin is **not** installed (or if it is installed, make sure it is not the default editor in the plugin settings)
 
 ### Editing unsupported blocks is allowed on Gutenberg-enabled Atomic sites
 
-1. On the site described above, add a post, then add a block that's not yet supported on mobile (e.g. Audio at time of writing)
+1. On the site described above, add a post, then add a block that's not yet supported on mobile (e.g. Jetpack Markdown at time of writing)
 2. Log into the WordPress mobile app using the site's WP.com account
 3. Open the post and expect to see the block rendered as a placeholder with the text "Unsupported"
 4. Tap the `(?)` icon and expect the option to edit the block in a web browser to be shown
@@ -56,17 +60,21 @@ A WP.com Atomic site (i.e. a WP.com site with a Business plan) with the **Gutenb
 
 ##### TC004
 
+**Known Issues**
+-  **[iOS and Android]** [Editing unsupported blocks is not enabled on sites accessed via older WP.com accounts](https://github.com/wordpress-mobile/gutenberg-mobile/issues/3425)
+
 #### Precondition
 
 A WP.com Atomic site (i.e. a WP.com site with a Business plan) with the **Classic editor** set as the default. Here are the steps for creating this if necessary:
 
 1. Find a site with a Business plan or higher
-2. Install and activate the Classic Editor plugin
-3. In Calypso choose your site and go to Tools | Plugins | Installed Plugins, then tap Settings under the Classic Editor plugin and set **Default editor for all users** to **Classic Editor**
+2. Find an account created in 2019 or later (account age is found under https://wordpress.com/me/account), otherwise the known issue listed above will break the Unsupported Block Editor.
+3. Install and activate the Classic Editor plugin
+4. In Calypso choose your site and go to Tools | Plugins | Installed Plugins, then tap Settings under the Classic Editor plugin and set **Default editor for all users** to **Classic Editor**
 
 ### Editing unsupported blocks is disallowed on Classic-enabled Atomic sites
 
-1. On the site described above, add a post, then add a block that's not yet supported on mobile (e.g. Audio at time of writing)
+1. On the site described above, add a post, then add a block that's not yet supported on mobile (e.g. Jetpack Markdown at time of writing)
 2. Log into the WordPress mobile app using the site's WP.com account
 3. Open the post and expect to see the block rendered as a placeholder with the text "Unsupported"
 4. Tap the `(?)` icon and expect to NOT see an option to edit the block in a web browser
@@ -87,11 +95,11 @@ For this test, you need a self-hosted site with the Jetpack plugin installed, ac
 
 ### Editing unsupported blocks is enabled on self-hosted sites accessed via Jetpack
 
-1. On the site described above, add a post, then add a block that's not yet supported on mobile (e.g. Audio at time of writing) via the site's WP Admin web interface
+1. On the site described above, add a post, then add a block that's not yet supported on mobile (e.g. Jetpack Markdown at time of writing) via the site's WP Admin web interface
 2. Log into the WordPress mobile app using the WP.com account that was used to connect Jetpack to the self-hosted site
 3. Open the post and expect to see the unsupported block rendered as a placeholder with the text "Unsupported"
 4. Tap the `(?)` icon and expect to see an option to enable `Login with WordPress.com`.
-5. Tap on that option, and enable `Loogin with WordPress.com` on the screen presented.
+5. Tap on that option, and enable `Login with WordPress.com` on the screen presented.
 4. Go back and tap the `(?)` icon.
 5. Expect the option to edit the block in a web browser to be shown
 6. Tap the edit in a web browser button and expect a web view requesting to `Login with WordPress.com`.
@@ -114,7 +122,7 @@ For this test, you need a self-hosted site with its own login credentials (we're
 
 ### Editing unsupported blocks is disallowed on self-hosted sites accessed via their own username and password
 
-1. On the site described above, add a post, then add a block that's not yet supported on mobile (e.g. Audio at time of writing) via the site's WP Admin web interface
+1. On the site described above, add a post, then add a block that's not yet supported on mobile (e.g. RSS at time of writing) via the site's WP Admin web interface
 2. Log into the WordPress mobile app by adding the site address and subsequently authenticating with the site username and password
 3. Open the post and expect to see the unsupported block rendered as a placeholder with the text "Unsupported"
 4. Tap the `(?)` icon and expect to NOT see an option to edit the block in a web browser


### PR DESCRIPTION
While fixing https://github.com/wordpress-mobile/gutenberg-mobile/issues/3425, I noticed that some test cases were outdated and needed updating.
Some changes were because the Audio block is no-longer an unsupported block, and other changes were to update the known issues of the Unsupported Block Editor.