### PR TITLE
Removed deprecated classic editor test case

### DIFF
--- a/test-cases/gutenberg/image.md
+++ b/test-cases/gutenberg/image.md
@@ -73,15 +73,6 @@ A site with premium or business plan
 --------------------------------------------------------------------------------
 ##### TC006
 
-**Switch to classic editor with an image block in page**
-
--   Add an image block and insert image
--   Switch to classic editor
--   Verify that you see the image there too
-
---------------------------------------------------------------------------------
-##### TC007
-
 **Border style setting**
 
 **Steps**
@@ -98,7 +89,7 @@ A site with premium or business plan
 <br><img src="../resources/image-border-rounded.png" width=250 />
 
 --------------------------------------------------------------------------------
-##### TC008
+##### TC007
 
 **Image size setting**
 
@@ -117,7 +108,7 @@ A site with premium or business plan
 
 --------------------------------------------------------------------------------
 
-##### TC009
+##### TC008
 
 **Link to setting**
 

--- a/test-suites/gutenberg/sanity-test-suites.md
+++ b/test-suites/gutenberg/sanity-test-suites.md
@@ -236,10 +236,9 @@ This holds a grouping of certain test suites to run in order to share the work w
 - [ ] Social icon forwarding to the link - [TC006](https://github.com/wordpress-mobile/test-cases/blob/master/test-cases/gutenberg/social-icons.md#tc006)
 
 ### Image - 2
-- [ ] Image block - Switch to classic editor with an image block in page - [TC006](https://github.com/wordpress-mobile/test-cases/blob/master/test-cases/gutenberg/image.md#tc006)
-- [ ] Image block - Border style setting - [TC007](https://github.com/wordpress-mobile/test-cases/blob/master/test-cases/gutenberg/image.md#tc007)
-- [ ] Image block - Image size setting - [TC008](https://github.com/wordpress-mobile/test-cases/blob/master/test-cases/gutenberg/image.md#tc008)
-- [ ] Image block - Link to setting - [TC009](https://github.com/wordpress-mobile/test-cases/blob/master/test-cases/gutenberg/image.md#tc008)
+- [ ] Image block - Border style setting - [TC006](https://github.com/wordpress-mobile/test-cases/blob/master/test-cases/gutenberg/image.md#tc006)
+- [ ] Image block - Image size setting - [TC007](https://github.com/wordpress-mobile/test-cases/blob/master/test-cases/gutenberg/image.md#tc007)
+- [ ] Image block - Link to setting - [TC008](https://github.com/wordpress-mobile/test-cases/blob/master/test-cases/gutenberg/image.md#tc008)
 
 ### Story block - 1
 - [ ] Story block - Verify is available in Block Picker - [TC001](https://github.com/wordpress-mobile/test-cases/blob/master/test-cases/jetpack/story.md#tc001)


### PR DESCRIPTION
Removes the `Switch to classic editor with an image block in page` test case since the is no longer a way to switch a post from `gutenberg` to classic in the latest versions of the app.