### PR TITLE
Remove tests that involve switch to classic editor

### DIFF
--- a/config/mapping.json
+++ b/config/mapping.json
@@ -1,11 +1,11 @@
 [
 	{
 		"regex":"gutenberg/packages/block-library/src/image/edit.native.js",
-		"testFile": ["gutenberg/image-basic.md", "gutenberg/image-upload.md", "gutenberg/image-caption.md"]
+		"testFile": ["gutenberg/image-upload.md", "gutenberg/image-caption.md"]
 	},
 	{
 		"regex":"gutenberg/packages/block-library/src/video/edit.native.js",
-		"testFile": ["gutenberg/video-basic.md", "gutenberg/video-upload.md", "gutenberg/video-caption.md"]
+		"testFile": ["gutenberg/video-upload.md", "gutenberg/video-caption.md"]
 	},
 	{
 		"regex":"gutenberg/packages/block-editor/src/components/media-upload/index.native.js",

--- a/test-cases/gutenberg/video.md
+++ b/test-cases/gutenberg/video.md
@@ -41,13 +41,5 @@ Steps are same with [image block TC005](https://github.com/wordpress-mobile/test
 
 ![Upload progress](../resources/upload-progress-video.png)
 
-##### TC006
-
-**Switch to classic editor with a video block in page**
-
--   Add an video block and insert video
--   Switch to classic editor
--   Verify that you see the video there too and you can play it
-
 
 

--- a/test-suites/gutenberg/image-basic.md
+++ b/test-suites/gutenberg/image-basic.md
@@ -1,1 +1,0 @@
-- [ ] Image block - Switch to classic editor with an image block in page - [steps](https://github.com/wordpress-mobile/test-cases/blob/master/test-cases/gutenberg/image.md#tc006)

--- a/test-suites/gutenberg/video-basic.md
+++ b/test-suites/gutenberg/video-basic.md
@@ -1,1 +1,0 @@
-- [ ] Video block - Switch to classic editor with a video block in page - [steps](https://github.com/wordpress-mobile/test-cases/blob/master/test-cases/gutenberg/video.md#tc006)


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/test-cases/pull/89

Removes tests that require switching a post from the block editor to the classic editor, which is no longer possible.