### PR TITLE
Add embed block test cases

### DIFF
--- a/test-cases/README.md
+++ b/test-cases/README.md
@@ -23,6 +23,7 @@ Gutenberg:
 - [File block](./gutenberg/file.md)
 - [Audio block](./gutenberg/audio.md)
 - [Reusable block](./gutenberg/reusable.md)
+- [Embed block](./gutenberg/embed.md)
 
 Jetpack:
 

--- a/test-cases/gutenberg/embed.md
+++ b/test-cases/gutenberg/embed.md
@@ -33,9 +33,8 @@ Perform these tests for each of the top 5 most-used providers below.
 
 *Initial steps* 
 
-- Add an Embed block
+- Add an Embed block.
 - Add a valid embed URL.
-
 
 ### 1. Default alignment
 

--- a/test-cases/gutenberg/embed.md
+++ b/test-cases/gutenberg/embed.md
@@ -1,0 +1,89 @@
+# Embed Block - Test Cases
+##### TC001
+
+**Inline previews are rendered correctly for the top 5 most-used providers**
+
+#### **Precondition**
+
+Perform these tests for each of the top 5 most-used providers below. 
+ 1. YouTube
+ 2. Twitter
+ 3. Instagram
+ 4. WordPress
+ 5. Vimeo
+
+*Initial steps* 
+
+- Open the Inserter. 
+- Add a specific provider from the list above. 
+
+**Steps**
+- Add a link to be previewed. 
+
+**Expected Behavior**
+- Verify that there are no style issues and the preview is rendered as expected.
+
+--------------------------------------------------------------------------------
+
+##### TC002
+
+**Inline previews are rendered accordingly for each alignment option.**
+
+#### **Precondition**
+
+*Initial steps* 
+
+- Add an Embed block
+- Add a valid embed URL.
+
+
+### 1. Default alignment
+
+**Expected Behavior**
+- Observe that the preview content is centered and covers the entire block.
+
+### 2. Align left
+
+**Steps**
+- Tap on the align options located in the toolbar.
+- Tap on "Align left".
+
+**Expected Behavior**
+- Observe that the preview content is aligned left and only covers part of the block.
+
+### 3. Align center
+
+**Steps**
+- Tap on the align options located in the toolbar.
+- Tap on "Align center".
+
+**Expected Behavior**
+- Observe that the preview content is centered and covers the entire block.
+
+### 4. Align right
+- Tap on the align options located in the toolbar.
+- Tap on "Align right".
+
+**Expected Behavior**
+- Observe that the preview content is aligned right and only covers part of the block.
+
+### 5. Wide width
+**Steps**
+- Tap on the align options located in the toolbar.
+- Tap on "Wide width".
+
+**Expected Behavior**
+- Observe that the block's width is wider than the rest of the content and that the preview content covers the entire block.
+
+**NOTE:** Some embed content like Tweets won't cover the entire block because it's not designed for that purpose.
+
+### 6. Full width
+**Steps**
+- Tap on the align options located in the toolbar.
+- Tap on "Full width".
+
+**Expected Behavior**
+- Observe that the block's width covers the entire editor and that the preview content covers the entire block.
+
+
+--------------------------------------------------------------------------------

--- a/test-cases/gutenberg/embed.md
+++ b/test-cases/gutenberg/embed.md
@@ -41,6 +41,23 @@ Perform these tests for each of the top 5 most-used providers below.
 **Expected Behavior**
 - Observe that the preview content is centered and covers the entire block.
 
+
+<details><summary><strong>Screenshots</strong></summary>
+
+#### Resize mode ON
+
+Native editor|Web editor|Tablet preview
+--|--|--
+<img width="435" alt="align-empty-resize-native" src="https://user-images.githubusercontent.com/14905380/129926919-8a6a6fda-82ec-4ce6-93f8-ba2644f974ab.png">|<img width="817" alt="align-empty-resize-web" src="https://user-images.githubusercontent.com/14905380/129926934-44bd11b3-057e-49ea-b7d0-dde66947d781.png">|<img width="645" alt="align-empty-resize-preview" src="https://user-images.githubusercontent.com/14905380/129926944-b874271c-1219-4a67-aac7-522a237b1407.png">
+
+#### Resize mode OFF
+
+Native editor|Web editor|Tablet preview
+--|--|--
+<img width="438" alt="align-empty-no-resize-native" src="https://user-images.githubusercontent.com/14905380/129927067-3ef74173-b8b7-4913-b925-d981557dd124.png">|<img width="816" alt="align-empty-no-resize-web" src="https://user-images.githubusercontent.com/14905380/129927079-6e1d3d99-b827-4670-98a1-f3feced2a6ba.png">|<img width="643" alt="align-empty-no-resize-preview" src="https://user-images.githubusercontent.com/14905380/129927086-6e85f194-77c6-4b3e-97db-5903e1e7b805.png">
+
+</details>
+
 ### 2. Align left
 
 **Steps**
@@ -49,6 +66,22 @@ Perform these tests for each of the top 5 most-used providers below.
 
 **Expected Behavior**
 - Observe that the preview content is aligned left and only covers part of the block.
+
+<details><summary><strong>Screenshots</strong></summary>
+
+#### Resize mode ON
+
+Native editor|Web editor|Tablet preview
+--|--|--
+<img width="439" alt="align-left-resize-native" src="https://user-images.githubusercontent.com/14905380/129927325-69594b69-3072-49e7-a5db-68b9648e7af3.png">|<img width="796" alt="align-left-resize-web" src="https://user-images.githubusercontent.com/14905380/129927335-94c87703-0780-43f3-bfb4-d714eee431ba.png">|<img width="630" alt="align-left-resize-preview" src="https://user-images.githubusercontent.com/14905380/129927342-3b833c40-c41e-409d-9829-c9502438b06f.png">
+
+#### Resize mode OFF
+
+Native editor|Web editor|Tablet preview
+--|--|--
+<img width="440" alt="align-left-no-resize-native" src="https://user-images.githubusercontent.com/14905380/129927356-7fc2be60-ace4-422e-a1a8-ae31dd1ebdf9.png">|<img width="819" alt="align-left-no-resize-web" src="https://user-images.githubusercontent.com/14905380/129927360-42af644c-d8ed-4ceb-a245-25c2bbeab7c5.png">|<img width="630" alt="align-left-no-resize-preview" src="https://user-images.githubusercontent.com/14905380/129927364-3d1a1d93-7f7c-4774-811c-bd6635f2ecbe.png">
+
+</details>
 
 ### 3. Align center
 
@@ -59,12 +92,44 @@ Perform these tests for each of the top 5 most-used providers below.
 **Expected Behavior**
 - Observe that the preview content is centered and covers the entire block.
 
+<details><summary><strong>Screenshots</strong></summary>
+
+#### Resize mode ON
+
+Native editor|Web editor|Tablet preview
+--|--|--
+<img width="439" alt="align-center-resize-native" src="https://user-images.githubusercontent.com/14905380/129927613-af8b19e0-ee8a-44e3-90d6-f30c48f56fda.png">|<img width="808" alt="align-center-resize-web" src="https://user-images.githubusercontent.com/14905380/129927622-db1a9446-ee83-49ee-89e8-0754270dc60e.png">|<img width="634" alt="align-center-resize-preview" src="https://user-images.githubusercontent.com/14905380/129927628-5f4c2f2e-82bf-473c-af82-91c8f969ab84.png">
+
+#### Resize mode OFF
+
+Native editor|Web editor|Tablet preview
+--|--|--
+<img width="439" alt="align-center-no-resize-native" src="https://user-images.githubusercontent.com/14905380/129927650-2e9c6f8d-3e47-4a46-ada0-650e0b6c8f4f.png">|<img width="809" alt="align-center-no-resize-web" src="https://user-images.githubusercontent.com/14905380/129927656-78a18b82-fb29-4181-a6cd-e223f64e23a4.png">|<img width="635" alt="align-center-no-resize-preview" src="https://user-images.githubusercontent.com/14905380/129927667-b4e3afaf-fcf4-474b-8e9a-79dff073277b.png">
+
+</details>
+
 ### 4. Align right
 - Tap on the align options located in the toolbar.
 - Tap on "Align right".
 
 **Expected Behavior**
 - Observe that the preview content is aligned right and only covers part of the block.
+
+<details><summary><strong>Screenshots</strong></summary>
+
+#### Resize mode ON
+
+Native editor|Web editor|Tablet preview
+--|--|--
+<img width="434" alt="align-right-resize-native" src="https://user-images.githubusercontent.com/14905380/129927534-a9b19102-a84c-4313-89fc-d230747a8706.png">|<img width="814" alt="align-right-resize-web" src="https://user-images.githubusercontent.com/14905380/129927545-08fa735e-1a72-4a82-bd9f-409b74b790de.png">|<img width="640" alt="align-right-resize-preview" src="https://user-images.githubusercontent.com/14905380/129927551-57ebdb73-936c-4bec-b776-36586e05951d.png">
+
+#### Resize mode OFF
+
+Native editor|Web editor|Tablet preview
+--|--|--
+<img width="442" alt="align-right-no-resize-native" src="https://user-images.githubusercontent.com/14905380/129927566-87f7e447-f4a0-4cf6-9074-0d27b7192a30.png">|<img width="818" alt="align-right-no-resize-web" src="https://user-images.githubusercontent.com/14905380/129927569-48b33d5a-a561-4d56-8045-e96f2be05d47.png">|<img width="640" alt="align-right-no-resize-preview" src="https://user-images.githubusercontent.com/14905380/129927572-0fa2bbcf-c135-4824-b36b-75c239d51688.png">
+
+</details>
 
 ### 5. Wide width
 **Steps**
@@ -76,6 +141,22 @@ Perform these tests for each of the top 5 most-used providers below.
 
 **NOTE:** Some embed content like Tweets won't cover the entire block because it's not designed for that purpose.
 
+<details><summary><strong>Screenshots</strong></summary>
+
+#### Resize mode ON
+
+Native editor|Web editor|Tablet preview
+--|--|--
+<img width="742" alt="wide-width-resize-native" src="https://user-images.githubusercontent.com/14905380/129927759-4442384b-aa67-4e1b-8c3c-e6e2075883ac.png">|<img width="1067" alt="wide-width-resize-web" src="https://user-images.githubusercontent.com/14905380/129927764-581596b0-6320-4967-a4f7-977e58ffb5a1.png">|<img width="904" alt="wide-width-resize-preview" src="https://user-images.githubusercontent.com/14905380/129927767-1d91e2d3-77c9-42af-93d6-3c859f8e99df.png">
+
+#### Resize mode OFF
+
+Native editor|Web editor|Tablet preview
+--|--|--
+<img width="745" alt="wide-width-no-resize-native" src="https://user-images.githubusercontent.com/14905380/129927789-b3bf02c3-c373-4883-a7f6-be832d5e6968.png">|<img width="1060" alt="wide-width-no-resize-web" src="https://user-images.githubusercontent.com/14905380/129927810-8a92ba7b-2e31-461f-b9fa-b1e3c878b292.png">|<img width="709" alt="wide-width-no-resize-preview" src="https://user-images.githubusercontent.com/14905380/129927817-a7035b18-e6f5-48db-be78-30536c79b4c6.png">
+
+</details>
+
 ### 6. Full width
 **Steps**
 - Tap on the align options located in the toolbar.
@@ -85,4 +166,19 @@ Perform these tests for each of the top 5 most-used providers below.
 - Observe that the block's width covers the entire editor and that the preview content covers the entire block.
 
 
---------------------------------------------------------------------------------
+
+<details><summary><strong>Screenshots</strong></summary>
+
+#### Resize mode ON
+
+Native editor|Web editor|Tablet preview
+--|--|--
+<img width="770" alt="full-width-resize-native" src="https://user-images.githubusercontent.com/14905380/129928311-d1130c3c-05c8-4634-904c-59e7f71e4ed1.png">|<img width="1331" alt="full-width-resize-web" src="https://user-images.githubusercontent.com/14905380/129928322-dd75017e-2d5c-4d8c-9a75-90302cc00e57.png">|<img width="941" alt="full-width-resize-preview" src="https://user-images.githubusercontent.com/14905380/129928327-ac40fb2b-8f88-42fe-b7d0-90d09b4ec52f.png">
+
+#### Resize mode OFF
+
+Native editor|Web editor|Tablet preview
+--|--|--
+<img width="760" alt="full-width-no-resize-native" src="https://user-images.githubusercontent.com/14905380/129928356-bd14f624-b100-4ecf-b9c0-b9bbd5711e56.png">|<img width="1290" alt="full-width-no-resize-web" src="https://user-images.githubusercontent.com/14905380/129928373-5045c28e-5d27-443b-abe2-7a07fcc3ded1.png">|<img width="712" alt="full-width-no-resize-preview" src="https://user-images.githubusercontent.com/14905380/129928378-658de132-b5d0-466c-98cb-536ddfbff252.png">
+
+</details>

--- a/test-cases/gutenberg/embed.md
+++ b/test-cases/gutenberg/embed.md
@@ -5,7 +5,10 @@
 
 #### **Precondition**
 
-Perform these tests for each of the top 5 most-used providers below. 
+Perform these tests for each of the top 5 most-used providers below.
+
+N.B Instagram only works on WP.com sites or self hosted sites with a Jetpack connection. 
+
  1. YouTube
  2. Twitter
  3. Instagram


### PR DESCRIPTION
Test cases

- Verify that inline previews are rendered properly for the top 5 most-used providers (YouTube, Twitter, Instagram, WordPress and Vimeo).

- Verify that inline previews are rendered accordingly for each alignment option.