### PR TITLE
Update Link To clipboard integration steps

### DIFF
--- a/test-cases/gutenberg/buttons.md
+++ b/test-cases/gutenberg/buttons.md
@@ -105,7 +105,7 @@
 
 ##### TC008
 
-### Link from the clipboard is automatically added into the empty URL field in link settings and button options
+### Link from the clipboard is presented as an option in the link picker
 
 -   Copy link into clipboard, e.g. `http://wordpress.com`
 -   Add `Buttons` block

--- a/test-cases/gutenberg/buttons.md
+++ b/test-cases/gutenberg/buttons.md
@@ -110,6 +110,8 @@
 -   Copy link into clipboard, e.g. `http://wordpress.com`
 -   Add `Buttons` block
 -   Open link [settings](../resources/button-link-settings.png)
+-   Edit the `Link to` field.
+-   Tap the `From clipboard` option.
 -   Expect link from the clipboard to be automatically added into the empty URL field
 
 --------------------------------------------------------------------------------

--- a/test-suites/gutenberg/sanity-test-suites.md
+++ b/test-suites/gutenberg/sanity-test-suites.md
@@ -297,7 +297,7 @@ This holds a grouping of certain test suites to run in order to share the work w
 
 ### Buttons - 7
 
-- [ ] Buttons block - Link from the clipboard is automatically added into the empty URL field in link settings and button options - [TC008](https://github.com/wordpress-mobile/test-cases/blob/master/test-cases/gutenberg/buttons.md#tc008)
+- [ ] Buttons block - Link from the clipboard is presented as an option in the link picker - [TC008](https://github.com/wordpress-mobile/test-cases/blob/master/test-cases/gutenberg/buttons.md#tc008)
 - [ ] Buttons block - Toolbar link button is active when Button has link - [TC022](https://github.com/wordpress-mobile/test-cases/blob/master/test-cases/gutenberg/buttons.md#tc022)
 
 ### Editor Theme - 2

--- a/test-suites/gutenberg/sanity-tests.md
+++ b/test-suites/gutenberg/sanity-tests.md
@@ -113,7 +113,7 @@ Button-6
 
 Button-7
 
-- [ ] Buttons block - Link from the clipboard is automatically added into the empty URL field in link settings and button options - [steps](https://github.com/wordpress-mobile/test-cases/blob/master/test-cases/gutenberg/buttons.md#tc008)
+- [ ] Buttons block - Link from the clipboard is presented as an option in the link picker - [steps](https://github.com/wordpress-mobile/test-cases/blob/master/test-cases/gutenberg/buttons.md#tc008)
 - [ ] Buttons block - Toolbar link button is active when Button has link - [steps](https://github.com/wordpress-mobile/test-cases/blob/master/test-cases/gutenberg/buttons.md#tc022)
 
 Group-1


### PR DESCRIPTION
Clipboard strings no longer auto-populate the `Link to` field when opening the link settings. The user must now explicitly select to paste the URL from their clipboard. https://github.com/WordPress/gutenberg/pull/35972
