### PR TITLE
Fix test suite heading

### DIFF
--- a/test-suites/gutenberg/sanity-test-suites.md
+++ b/test-suites/gutenberg/sanity-test-suites.md
@@ -311,7 +311,7 @@ This holds a grouping of certain test suites to run in order to share the work w
 
 ```
 
-## Test Suite 4
+## Test Suite 5
 
 - Video block 1-2
 - File block 1-3


### PR DESCRIPTION
The documentation included two "Test Suite 4" headings. In reality there are five test suites.
