### PR TITLE
Add highlight text cases to writing flow checklist

### DIFF
--- a/test-cases/gutenberg/writing-flow/readme.md
+++ b/test-cases/gutenberg/writing-flow/readme.md
@@ -10,6 +10,8 @@
   - [ ] Pullquote block
 #### Rich Text Format
 - [ ] [TC001](https://github.com/wordpress-mobile/test-cases/blob/trunk/test-cases/gutenberg/writing-flow/rich-text-formatting.md#tc001) - Bold, Italic, strikethrough buttons
+- [ ] [TC001](https://github.com/wordpress-mobile/test-cases/blob/trunk/test-cases/gutenberg/writing-flow/rich-text-formatting.md#tc001) - Highlight selected text
+- [ ] [TC001](https://github.com/wordpress-mobile/test-cases/blob/trunk/test-cases/gutenberg/writing-flow/rich-text-formatting.md#tc001) - Highlight text without selection
 - [ ] [TC002](https://github.com/wordpress-mobile/test-cases/blob/trunk/test-cases/gutenberg/writing-flow/rich-text-formatting.md#tc002) - Alignment buttons
 - [ ] [TC003](https://github.com/wordpress-mobile/test-cases/blob/trunk/test-cases/gutenberg/writing-flow/rich-text-formatting.md#tc003) - Alignment Split
 - [ ] [TC004](https://github.com/wordpress-mobile/test-cases/blob/trunk/test-cases/gutenberg/writing-flow/rich-text-formatting.md#tc004) - Link button works without selection


### PR DESCRIPTION
I noticed that the following test cases related to highlight text are not included in [the writing flow checklist](https://github.com/wordpress-mobile/test-cases/tree/trunk/test-cases/gutenberg/writing-flow):
- Highlight selected text
- Highlight text without selection

I added them using the same test case ID `TC001` as the other test `Bold, Italic, strikethrough buttons`, since they are part of the same test case ([reference](https://github.com/wordpress-mobile/test-cases/blob/trunk/test-cases/gutenberg/writing-flow/rich-text-formatting.md#tc001)).
