### PR TITLE
Remove known issue #2154 from test cases

### DIFF
--- a/test-cases/gutenberg/gallery.md
+++ b/test-cases/gutenberg/gallery.md
@@ -83,9 +83,6 @@ Gallery block should allow uploading multiple images after the editor is closed.
 -   Save the post
 -   Open it and expect to see the captions with their styles
 
-##### Known issues
-[Formating buttons aren’t updated accordingly when text is deleted](https://github.com/wordpress-mobile/gutenberg-mobile/issues/2154)
-
 --------------------------------------------------------------------------------
 
 ##### TC004

--- a/test-cases/gutenberg/writing-flow/rich-text-formatting.md
+++ b/test-cases/gutenberg/writing-flow/rich-text-formatting.md
@@ -86,9 +86,6 @@ Move the cursor around
 - Check that the proper format buttons get selected when the cursor get under a formatted word.
 
 
-**Known Issues**
-- Formating buttons aren’t updated accordingly when text is deleted [#2154](https://github.com/wordpress-mobile/gutenberg-mobile/issues/2154)
-
 ##### TC008
 
 **Test formatting doesn't remove leading or trailing whitespace**


### PR DESCRIPTION
Now that the known issue ["Formating buttons aren’t updated accordingly when text is deleted" #2154](https://github.com/wordpress-mobile/gutenberg-mobile/issues/2154) is already solved, we can remove the reference from the test cases.