### PR TITLE
Writing Flow checklist: Update known issues for 'multiline components' test cases

### DIFF
--- a/test-cases/gutenberg/writing-flow/multiline-components.md
+++ b/test-cases/gutenberg/writing-flow/multiline-components.md
@@ -14,6 +14,7 @@ Test the next steps on:
 
 - On Android, tapping Enter to split a quote or pullquote citation both splits the block and adds a newline to the citation ([#2498](https://github.com/wordpress-mobile/gutenberg-mobile/issues/2498))
 - On Android, there is sometimes a loss of lines when entering multiple lines. ([#29861](https://github.com/WordPress/gutenberg/issues/29861))
+- On Android, the line spacing between the first two lines in the preformatted and verse blocks appear closer together in the editor than other lines. ([#38636](https://github.com/WordPress/gutenberg/issues/38636))
 - There is sometimes inconsistent HTML surrounding newlines in the Pullquote and Quote Block. ([#1396](https://github.com/wordpress-mobile/gutenberg-mobile/issues/1396))
 
 **New line on multiline components**


### PR DESCRIPTION
The following issue can be encountered while going through [the 'multiline components' test cases](https://github.com/wordpress-mobile/test-cases/blob/trunk/test-cases/gutenberg/writing-flow/multiline-components.md#tc001): 

* https://github.com/WordPress/gutenberg/issues/38636

With this PR, a note about that issue is added to the "known issues" section, to help testers more easily identify the fact it's already been reported. 