### PR TITLE
[Gallery Block] Update test suite to reflect the fact "link to" settings are no longer broken

### DIFF
--- a/test-cases/gutenberg/gallery.md
+++ b/test-cases/gutenberg/gallery.md
@@ -259,8 +259,6 @@ Gallery block should allow uploading images from the iOS Files app.
 
 ### Settings - Link to
 
-**KNOWN ISSUE**: This test case is not currently working. Please skip. [See here](https://github.com/WordPress/gutenberg/issues/23576) for more details.
-
 **Precondition:** these steps should be tested via a self-hosted site
 
 Gallery images should respect the `Link to` setting


### PR DESCRIPTION
The [Gallery test suite](https://github.com/wordpress-mobile/test-cases/blob/trunk/test-cases/gutenberg/gallery.md) previously had the following note above the steps to test the block's "link to" settings:

```
**KNOWN ISSUE**: This test case is not currently working. Please skip. [See here](https://github.com/WordPress/gutenberg/issues/23576) for more details.
```

This issue was fixed in https://github.com/WordPress/gutenberg/pull/40947, so the settings should be working as expected again. As such, this PR removes the note.