### PR TITLE
docs: Remove outdated known Gallery block issue

### DIFF
--- a/test-cases/gutenberg/gallery.md
+++ b/test-cases/gutenberg/gallery.md
@@ -31,11 +31,6 @@ Gallery block should continue normally if the editor is closed and re-opened wit
   * Image should not be dim
   * Image url scheme should be `https://` (not `file:///`) in HTML mode
 
-##### Known issue:
-
-If the user leaves the editor and returns while the image is uploading, _and_ the upload finishes before the React Native editor has fully loaded, the upload completion event is missed, resulting in a UI state indicating a failed upload, even when the upload has completed.
-- [Invalid image URL after Close/Re-opening Gallery multiple times during upload of multiple images](https://github.com/wordpress-mobile/gutenberg-mobile/issues/2154)
-
 --------------------------------------------------------------------------------
 
 ##### TC002


### PR DESCRIPTION
The referenced known issue was the incorrect PR. Also, the correct PR appears to be marked as resolved. https://github.com/wordpress-mobile/gutenberg-mobile/issues/2041#event-3468328977