### PR TITLE
docs: Update outdated test cases

### DIFF
--- a/test-cases/gutenberg/buttons.md
+++ b/test-cases/gutenberg/buttons.md
@@ -59,19 +59,6 @@
 
 --------------------------------------------------------------------------------
 
-##### TC008
-
-### Link from the clipboard is presented as an option in the link picker
-
--   Copy link into clipboard, e.g. `http://wordpress.com`
--   Add `Buttons` block
--   Open link [settings](../resources/button-link-settings.png)
--   Edit the `Link to` field.
--   Tap the `From clipboard` option.
--   Expect link from the clipboard to be automatically added into the empty URL field
-
---------------------------------------------------------------------------------
-
 ##### TC005
 
 ### Edit text styles
@@ -261,5 +248,18 @@
 -   Add next button using inline appender or inserter
 -   Select the first one and type some characters
 -   Expect button's width grows properly (_horizontally_)
+
+--------------------------------------------------------------------------------
+
+##### TC020
+
+### Link from the clipboard is presented as an option in the link picker
+
+-   Copy link into clipboard, e.g. `http://wordpress.com`
+-   Add `Buttons` block
+-   Open link [settings](../resources/button-link-settings.png)
+-   Edit the `Link to` field.
+-   Tap the `From clipboard` option.
+-   Expect link from the clipboard to be automatically added into the empty URL field
 
 --------------------------------------------------------------------------------

--- a/test-cases/gutenberg/buttons.md
+++ b/test-cases/gutenberg/buttons.md
@@ -20,7 +20,7 @@
 -   Add `Buttons` block
 -   Press an inline appender
 -   Expect a new `Button` is added and focused
--   Press trash button
+-   Open the `Button` block settings and remove the block
 -   Expect current `Button` is removed and the previous `Button` is focused
 -   Press an inline appender
 -   Expect a new `Button` is added and focused

--- a/test-cases/gutenberg/group.md
+++ b/test-cases/gutenberg/group.md
@@ -32,7 +32,7 @@ Expected look:
 -   Nest some `Group` inside
 -   Select top-most `Group` block in hierarchy
 -   Check if you are able to see `Group` placeholder of nested blocks wrapped with dashed border
--   Go down in the hierarchy observing if margins is keept (the whole UI should remain the same)
+-   Go down in the hierarchy observing if margins is kept (the whole UI should remain the same)
 -   After selecting last `Group` you should be able to see it's `AppenderButton`
 
 Expected look:  

--- a/test-cases/gutenberg/group.md
+++ b/test-cases/gutenberg/group.md
@@ -3,7 +3,7 @@
 --------------------------------------------------------------------------------
 ##### TC001
 
-### Deep nesting is possible 
+### Deep nesting is possible (verify iOS does not crash)
 
 -   Add a `Group` block
 -   Nest blocks inside multiple `Group` blocks (at least 3 levels deep)

--- a/test-cases/gutenberg/group.md
+++ b/test-cases/gutenberg/group.md
@@ -3,7 +3,7 @@
 --------------------------------------------------------------------------------
 ##### TC001
 
-### Deep nesting is possible (iOS only)
+### Deep nesting is possible 
 
 -   Add a `Group` block
 -   Nest blocks inside multiple `Group` blocks (at least 3 levels deep)

--- a/test-suites/gutenberg/sanity-test-suites.md
+++ b/test-suites/gutenberg/sanity-test-suites.md
@@ -98,7 +98,7 @@ This holds a grouping of certain test suites to run in order to share the work w
 
 ### Group - 1
 
-- [ ] Group - Deep nesting is possible (iOS only) - [TC001](https://github.com/wordpress-mobile/test-cases/blob/master/test-cases/gutenberg/group.md#tc001)
+- [ ] Group - Deep nesting is possible - [TC001](https://github.com/wordpress-mobile/test-cases/blob/master/test-cases/gutenberg/group.md#tc001)
 - [ ] Group - Check if Group placeholder is visible for the unselected state - [TC002](https://github.com/wordpress-mobile/test-cases/blob/master/test-cases/gutenberg/group.md#tc002)
 - [ ] Group - Check if Group placeholder is render in nested structure - [TC003](https://github.com/wordpress-mobile/test-cases/blob/master/test-cases/gutenberg/group.md#tc003)
 - [ ] Group - Nested block have proper border styling - [TC004](https://github.com/wordpress-mobile/test-cases/blob/master/test-cases/gutenberg/group.md#tc004)

--- a/test-suites/gutenberg/sanity-test-suites.md
+++ b/test-suites/gutenberg/sanity-test-suites.md
@@ -98,7 +98,7 @@ This holds a grouping of certain test suites to run in order to share the work w
 
 ### Group - 1
 
-- [ ] Group - Deep nesting is possible - [TC001](https://github.com/wordpress-mobile/test-cases/blob/master/test-cases/gutenberg/group.md#tc001)
+- [ ] Group - Deep nesting is possible (verify iOS does not crash) - [TC001](https://github.com/wordpress-mobile/test-cases/blob/master/test-cases/gutenberg/group.md#tc001)
 - [ ] Group - Check if Group placeholder is visible for the unselected state - [TC002](https://github.com/wordpress-mobile/test-cases/blob/master/test-cases/gutenberg/group.md#tc002)
 - [ ] Group - Check if Group placeholder is render in nested structure - [TC003](https://github.com/wordpress-mobile/test-cases/blob/master/test-cases/gutenberg/group.md#tc003)
 - [ ] Group - Nested block have proper border styling - [TC004](https://github.com/wordpress-mobile/test-cases/blob/master/test-cases/gutenberg/group.md#tc004)

--- a/test-suites/gutenberg/sanity-test-suites.md
+++ b/test-suites/gutenberg/sanity-test-suites.md
@@ -102,7 +102,7 @@ This holds a grouping of certain test suites to run in order to share the work w
 - [ ] Group - Check if Group placeholder is visible for the unselected state - [TC002](https://github.com/wordpress-mobile/test-cases/blob/master/test-cases/gutenberg/group.md#tc002)
 - [ ] Group - Check if Group placeholder is render in nested structure - [TC003](https://github.com/wordpress-mobile/test-cases/blob/master/test-cases/gutenberg/group.md#tc003)
 - [ ] Group - Nested block have proper border styling - [TC004](https://github.com/wordpress-mobile/test-cases/blob/master/test-cases/gutenberg/group.md#tc004)
-- [ ] Group - Breadcrumbs on FloatingToolbar is properly displayed - [TC008](https://github.com/wordpress-mobile/test-cases/blob/master/test-cases/gutenberg/group.md#tc005)
+- [ ] Group - Breadcrumbs on FloatingToolbar is properly displayed - [TC005](https://github.com/wordpress-mobile/test-cases/blob/master/test-cases/gutenberg/group.md#tc005)
 
 ### Buttons-1
 

--- a/test-suites/gutenberg/sanity-test-suites.md
+++ b/test-suites/gutenberg/sanity-test-suites.md
@@ -256,7 +256,7 @@ This holds a grouping of certain test suites to run in order to share the work w
 
 ### Buttons - 7
 
-- [ ] Buttons block - Link from the clipboard is presented as an option in the link picker - [TC008](https://github.com/wordpress-mobile/test-cases/blob/master/test-cases/gutenberg/buttons.md#tc008)
+- [ ] Buttons block - Link from the clipboard is presented as an option in the link picker - [TC020](https://github.com/wordpress-mobile/test-cases/blob/master/test-cases/gutenberg/buttons.md#tc020)
 - [ ] Buttons block - Toolbar link button is active when Button has link - [TC018](https://github.com/wordpress-mobile/test-cases/blob/master/test-cases/gutenberg/buttons.md#tc018)
 
 ### Editor Theme - 2

--- a/test-suites/gutenberg/sanity-test-suites.md
+++ b/test-suites/gutenberg/sanity-test-suites.md
@@ -108,7 +108,7 @@ This holds a grouping of certain test suites to run in order to share the work w
 
 - [ ] Buttons block - Button's wrapper grows properly - [TC019](https://github.com/wordpress-mobile/test-cases/blob/master/test-cases/gutenberg/buttons.md#tc019)
 - [ ] Buttons block - Removing exactly one Button (when Buttons contain more of them) - [TC002](https://github.com/wordpress-mobile/test-cases/blob/master/test-cases/gutenberg/buttons.md#tc002)
-- [ ] Buttons block - Wrapping Buttons - [TC002](https://github.com/wordpress-mobile/test-cases/blob/master/test-cases/gutenberg/buttons.md#tc003)
+- [ ] Buttons block - Wrapping Buttons - [TC003](https://github.com/wordpress-mobile/test-cases/blob/master/test-cases/gutenberg/buttons.md#tc003)
 
 ### Button-2
 

--- a/test-suites/gutenberg/sanity-tests.md
+++ b/test-suites/gutenberg/sanity-tests.md
@@ -102,7 +102,7 @@ Button-6
 
 Button-7
 
-- [ ] Buttons block - Link from the clipboard is presented as an option in the link picker - [steps](https://github.com/wordpress-mobile/test-cases/blob/master/test-cases/gutenberg/buttons.md#tc008)
+- [ ] Buttons block - Link from the clipboard is presented as an option in the link picker - [steps](https://github.com/wordpress-mobile/test-cases/blob/master/test-cases/gutenberg/buttons.md#tc020)
 - [ ] Buttons block - Toolbar link button is active when Button has link - [steps](https://github.com/wordpress-mobile/test-cases/blob/master/test-cases/gutenberg/buttons.md#tc018)
 
 Group-1


### PR DESCRIPTION
Fix various errors in the test cases:

- docs: Remove outdated platform-specific note
- docs: Fix typos
- docs: Fix duplicate TC008 identifier
- docs: Fix typo
- docs: Update outdated UI description
