### PR TITLE
Update new-line tag used in the Pullquote block

### DIFF
--- a/test-cases/gutenberg/writing-flow/multiline-components.md
+++ b/test-cases/gutenberg/writing-flow/multiline-components.md
@@ -29,5 +29,5 @@ Test the next steps on:
   - _Verse_: `<br>` on line-breaks.
   - _Preformatted_: `<br>` on line-breaks.
   - _Code_: (Invisible `\n`) new line character.
-  - _Pullquote_: `<p>` tags per non-wrapping "line"
+  - _Pullquote_: `<br>` on line-breaks.
   - _Pullquote citation_: `<br>` on line-breaks.


### PR DESCRIPTION
After changes introduced in https://github.com/WordPress/gutenberg/pull/43210, the Pullquote block uses `br` HTML tag when creating new lines. Hence, the _Multiline components - Test Cases_ have been updated to reflect this change.