### PR TITLE
docs: Update Audio block alignment case

### DIFF
--- a/test-cases/gutenberg/audio.md
+++ b/test-cases/gutenberg/audio.md
@@ -151,7 +151,10 @@
 
 **Expected Behavior**
 
-- Currently only the full width option is supported.
+- Available options: None, Align left, Align center, Align right, Wide width, Full width
+- Align left/right results in text beneath the block to wrap the Audio block.
+- Wide width: Audio block expands past the rest of the post content.
+- Full width: Audio block expands to the edges of the window.
 
 --------------------------------------------------------------------------------
 ##### TC008


### PR DESCRIPTION
The Audio block appears to no longer be limited to the "Full width"
option.
