### PR TITLE
Update File block test case to reflect how to add a file on each platform

### DIFF
--- a/test-cases/gutenberg/file.md
+++ b/test-cases/gutenberg/file.md
@@ -6,7 +6,8 @@
 
 **Steps**
 - Tap on Choose a file on the placeholder. 
-- Tap option "Choose from device" and choose a file. 
+- **When using Android:** Tap option "Choose from device" and choose a file. 
+- **When using iOS:** Tap option "Other apps" and choose a file. 
 
 **Expected Behavior**
 - Expect to see the upload indicator and the Download button should be dimmed.


### PR DESCRIPTION
This PR updates the File block test case to reflect how to add a file on each platform (the iOS case was missing).