### PR TITLE
Remove Buttons block TC020 test case

### DIFF
--- a/test-cases/gutenberg/buttons.md
+++ b/test-cases/gutenberg/buttons.md
@@ -250,16 +250,3 @@
 -   Expect button's width grows properly (_horizontally_)
 
 --------------------------------------------------------------------------------
-
-##### TC020
-
-### Link from the clipboard is presented as an option in the link picker
-
--   Copy link into clipboard, e.g. `http://wordpress.com`
--   Add `Buttons` block
--   Open link [settings](../resources/button-link-settings.png)
--   Edit the `Link to` field.
--   Tap the `From clipboard` option.
--   Expect link from the clipboard to be automatically added into the empty URL field
-
---------------------------------------------------------------------------------

--- a/test-suites/gutenberg/functionality-test-suites.md
+++ b/test-suites/gutenberg/functionality-test-suites.md
@@ -256,7 +256,6 @@ This holds a grouping of certain test suites to run in order to share the work w
 
 ### Buttons - 7
 
-- [ ] Buttons block - Link from the clipboard is presented as an option in the link picker - [TC020](https://github.com/wordpress-mobile/test-cases/blob/trunk/test-cases/gutenberg/buttons.md#tc020)
 - [ ] Buttons block - Toolbar link button is active when Button has link - [TC018](https://github.com/wordpress-mobile/test-cases/blob/trunk/test-cases/gutenberg/buttons.md#tc018)
 
 ### Editor Theme - 2

--- a/test-suites/gutenberg/functionality-tests.md
+++ b/test-suites/gutenberg/functionality-tests.md
@@ -102,7 +102,6 @@ Button-6
 
 Button-7
 
-- [ ] Buttons block - Link from the clipboard is presented as an option in the link picker - [steps](https://github.com/wordpress-mobile/test-cases/blob/trunk/test-cases/gutenberg/buttons.md#tc020)
 - [ ] Buttons block - Toolbar link button is active when Button has link - [steps](https://github.com/wordpress-mobile/test-cases/blob/trunk/test-cases/gutenberg/buttons.md#tc018)
 
 Group-1


### PR DESCRIPTION
Following https://github.com/wordpress-mobile/gutenberg-mobile/pull/5795, this PR removes the test case of Buttons block `Link from the clipboard is presented as an option in the link picker` as it's already covered by an integration test ([reference](https://github.com/WordPress/gutenberg/blob/97ab6b167cc0d9da6c5f0ecf6be9457570d33731/packages/components/src/mobile/link-settings/test/edit.native.js#L210-L255)).