### PR TITLE
Remove extra `.md` extension in VideoPress test case links

### DIFF
--- a/test-suites/gutenberg/functionality-test-suites.md
+++ b/test-suites/gutenberg/functionality-test-suites.md
@@ -140,9 +140,9 @@ This holds a grouping of certain test suites to run in order to share the work w
 - [ ] Drag and Drop Blocks - Drag block to the bottom of the content - [TC002](https://github.com/wordpress-mobile/test-cases/blob/trunk/test-cases/gutenberg/drag-and-drop-blocks.md#tc002)
 
 ### VideoPress - 2
-- [ ] VideoPress block - Player - [TC003](https://github.com/wordpress-mobile/test-cases/blob/trunk/test-cases/gutenberg/videopress.md.md#tc003)
-- [ ] VideoPress block - Private video - [TC005](https://github.com/wordpress-mobile/test-cases/blob/trunk/test-cases/gutenberg/videopress.md.md#tc005)
-- [ ] VideoPress block - Upload limit for Free users - [TC006](https://github.com/wordpress-mobile/test-cases/blob/trunk/test-cases/gutenberg/videopress.md.md#tc006)
+- [ ] VideoPress block - Player - [TC003](https://github.com/wordpress-mobile/test-cases/blob/trunk/test-cases/gutenberg/videopress.md#tc003)
+- [ ] VideoPress block - Private video - [TC005](https://github.com/wordpress-mobile/test-cases/blob/trunk/test-cases/gutenberg/videopress.md#tc005)
+- [ ] VideoPress block - Upload limit for Free users - [TC006](https://github.com/wordpress-mobile/test-cases/blob/trunk/test-cases/gutenberg/videopress.md#tc006)
 
 ```
 
@@ -276,9 +276,9 @@ This holds a grouping of certain test suites to run in order to share the work w
 - [ ] Custom color picker - [TC006](https://github.com/wordpress-mobile/test-cases/blob/trunk/test-cases/gutenberg/color-settings.md#tc006)
 
 ### VideoPress - 1
-- [ ] VideoPress block - Upload a video - [TC001](https://github.com/wordpress-mobile/test-cases/blob/trunk/test-cases/gutenberg/videopress.md.md#tc001)
-- [ ] VideoPress block - Add Caption - [TC002](https://github.com/wordpress-mobile/test-cases/blob/trunk/test-cases/gutenberg/videopress.md.md#tc002)
-- [ ] VideoPress block - Close post with an ongoing video upload - [TC004](https://github.com/wordpress-mobile/test-cases/blob/trunk/test-cases/gutenberg/videopress.md.md#tc004)
+- [ ] VideoPress block - Upload a video - [TC001](https://github.com/wordpress-mobile/test-cases/blob/trunk/test-cases/gutenberg/videopress.md#tc001)
+- [ ] VideoPress block - Add Caption - [TC002](https://github.com/wordpress-mobile/test-cases/blob/trunk/test-cases/gutenberg/videopress.md#tc002)
+- [ ] VideoPress block - Close post with an ongoing video upload - [TC004](https://github.com/wordpress-mobile/test-cases/blob/trunk/test-cases/gutenberg/videopress.md#tc004)
 
 ```
 

--- a/test-suites/gutenberg/functionality-tests.md
+++ b/test-suites/gutenberg/functionality-tests.md
@@ -248,12 +248,12 @@ Drag & drop blocks - 1
 
 VideoPress block - 1
 
-- [ ] VideoPress block - Upload a video - [steps](https://github.com/wordpress-mobile/test-cases/blob/trunk/test-cases/gutenberg/videopress.md.md#tc001)
-- [ ] VideoPress block - Add Caption - [steps](https://github.com/wordpress-mobile/test-cases/blob/trunk/test-cases/gutenberg/videopress.md.md#tc002)
-- [ ] VideoPress block - Close post with an ongoing video upload - [steps](https://github.com/wordpress-mobile/test-cases/blob/trunk/test-cases/gutenberg/videopress.md.md#tc004)
+- [ ] VideoPress block - Upload a video - [steps](https://github.com/wordpress-mobile/test-cases/blob/trunk/test-cases/gutenberg/videopress.md#tc001)
+- [ ] VideoPress block - Add Caption - [steps](https://github.com/wordpress-mobile/test-cases/blob/trunk/test-cases/gutenberg/videopress.md#tc002)
+- [ ] VideoPress block - Close post with an ongoing video upload - [steps](https://github.com/wordpress-mobile/test-cases/blob/trunk/test-cases/gutenberg/videopress.md#tc004)
 
 VideoPress block - 2
 
-- [ ] VideoPress block - Player - [steps](https://github.com/wordpress-mobile/test-cases/blob/trunk/test-cases/gutenberg/videopress.md.md#tc003)
-- [ ] VideoPress block - Private video - [steps](https://github.com/wordpress-mobile/test-cases/blob/trunk/test-cases/gutenberg/videopress.md.md#tc005)
-- [ ] VideoPress block - Upload limit for Free users - [steps](https://github.com/wordpress-mobile/test-cases/blob/trunk/test-cases/gutenberg/videopress.md.md#tc006)
+- [ ] VideoPress block - Player - [steps](https://github.com/wordpress-mobile/test-cases/blob/trunk/test-cases/gutenberg/videopress.md#tc003)
+- [ ] VideoPress block - Private video - [steps](https://github.com/wordpress-mobile/test-cases/blob/trunk/test-cases/gutenberg/videopress.md#tc005)
+- [ ] VideoPress block - Upload limit for Free users - [steps](https://github.com/wordpress-mobile/test-cases/blob/trunk/test-cases/gutenberg/videopress.md#tc006)


### PR DESCRIPTION
Fixes an issue on VideoPress test case links introduced in https://github.com/wordpress-mobile/test-cases/pull/137.