### PR TITLE
Add known issue to Color Settings test case

### DIFF
--- a/test-cases/gutenberg/color-settings.md
+++ b/test-cases/gutenberg/color-settings.md
@@ -47,6 +47,10 @@
 
 ### Scroll color palette to the end
 
+**Known Issues**
+
+- [Color settings do not scroll to reveal selected color/gradient at the end](https://github.com/WordPress/gutenberg/issues/42018)
+
 **Steps:**
 
 * Press `Custom` color picker (at the end of the list)


### PR DESCRIPTION
There is a long standing issue that prevents the color settings from scrolling to the end, as described in https://github.com/WordPress/gutenberg/issues/42018.

Due to this issue, the [TC003](https://github.com/wordpress-mobile/test-cases/blob/trunk/test-cases/gutenberg/color-settings.md#tc003) test case always fails. With this PR, a known issues marker is added to inform testers that this is known. 