### PR TITLE
Remove old test suite files

### DIFF
--- a/test-suites/gutenberg/sanity-test-suites.md
+++ b/test-suites/gutenberg/sanity-test-suites.md
@@ -1,1 +1,0 @@
-See [Functionality test suites](https://github.com/wordpress-mobile/test-cases/blob/HEAD/test-suites/gutenberg/functionality-test-suites.md)

--- a/test-suites/gutenberg/sanity-tests.md
+++ b/test-suites/gutenberg/sanity-tests.md
@@ -1,1 +1,0 @@
-See [Functionality test suites](https://github.com/wordpress-mobile/test-cases/blob/HEAD/test-suites/gutenberg/functionality-tests.md)


### PR DESCRIPTION
This PR removes old test suite files in favor of the new Functionality test suites due to language used.

This will undoubtedly break existing links, but we can update those as we go.