### PR TITLE
docs: Fix outdated test suites

### DIFF
--- a/test-cases/gutenberg/buttons.md
+++ b/test-cases/gutenberg/buttons.md
@@ -147,7 +147,7 @@
 
 -   Add `Buttons` block
 -   Open button [options](../resources/button-options.png)
--   Edit `Border Radius` moving slider
+-   Edit `Border Radius` by tapping the +/- buttons
 -   Expect Button border radius changed accordingly to the value
 -   Edit `Border Radius` typing border radius value in input
 -   Expect Button border radius changed accordingly to the value

--- a/test-cases/gutenberg/color-settings.md
+++ b/test-cases/gutenberg/color-settings.md
@@ -89,6 +89,7 @@
 **Known Issues**
 
 - [When deselecting a custom gradient the button does not slide out smoothly](https://github.com/wordpress-mobile/gutenberg-mobile/issues/3465)
+- [Selected custom gradient is not displayed in color settings](https://github.com/WordPress/gutenberg/issues/42017)
 
 ### Customize gradient color
 

--- a/test-cases/gutenberg/group.md
+++ b/test-cases/gutenberg/group.md
@@ -94,15 +94,13 @@ Expected look:
 
 ##### TC007
 
-### Navigation down works according to parent-first approach
+### Navigation down works according to deepest-descendent-first approach
 
 -   Add a `Group` block
 -   Create some nested structure ( at least 3 levels deep )
 -   Clear selection
 -   Press on the bottom-most block in hierarchy of added `Group`
--   Check if the selection is redirect properly to top-most parent
--   Repeat - press on the bottom-most block in hierarchy of added `Group`
--   Check if each time you press nested block you move selection one level down (block which gets selection should be common ancestor with previously selected block and pressed block)
+-   Check if the selection is redirect properly to depest descendant
 
 --------------------------------------------------------------------------------
 

--- a/test-suites/gutenberg/functionality-test-suites.md
+++ b/test-suites/gutenberg/functionality-test-suites.md
@@ -191,7 +191,6 @@ This holds a grouping of certain test suites to run in order to share the work w
 - [ ] Spacer block - Dark mode - [TC004](https://github.com/wordpress-mobile/test-cases/blob/trunk/test-cases/gutenberg/darkmode.md#tc004)
 - [ ] Buttons block - Dark mode - [TC005](https://github.com/wordpress-mobile/test-cases/blob/trunk/test-cases/gutenberg/darkmode.md#tc005)
 - [ ] Group - Dark mode - [TC006](https://github.com/wordpress-mobile/test-cases/blob/trunk/test-cases/gutenberg/darkmode.md#tc006)
-- [ ] Columns - Dark mode - [TC007](https://github.com/wordpress-mobile/test-cases/blob/trunk/test-cases/gutenberg/darkmode.md#tc007)
 
 ### Group - 2
 


### PR DESCRIPTION
Update various errors encountered when performing manual functionality tests.

- docs: Remove broken reference to removed Columns test case
- docs: Update Groups test to mirror deepest-descendent-first approach
- docs: Buttons radius interface uses stepper buttons
- docs: Capture known color settings issue
