### PR TITLE
Add known autocorrect issue to multiline component test cases

### DIFF
--- a/test-cases/gutenberg/writing-flow/multiline-components.md
+++ b/test-cases/gutenberg/writing-flow/multiline-components.md
@@ -15,7 +15,6 @@ Test the next steps on:
 - On Android, tapping Enter to split a quote or pullquote citation both splits the block and adds a newline to the citation ([#2498](https://github.com/wordpress-mobile/gutenberg-mobile/issues/2498))
 - On Android, there is sometimes a loss of lines when entering multiple lines. ([#29861](https://github.com/WordPress/gutenberg/issues/29861))
 - On Android, the line spacing between the first two lines in the preformatted and verse blocks appear closer together in the editor than other lines. ([#38636](https://github.com/WordPress/gutenberg/issues/38636))
-- On Android, auto-correction of the first word in the Verse or Preformatted block leads to it being deleted. ([#52887](https://github.com/WordPress/gutenberg/issues/52887))
 - There is sometimes inconsistent HTML surrounding newlines in the Pullquote and Quote Block. ([#1396](https://github.com/wordpress-mobile/gutenberg-mobile/issues/1396))
 
 **New line on multiline components**

--- a/test-cases/gutenberg/writing-flow/multiline-components.md
+++ b/test-cases/gutenberg/writing-flow/multiline-components.md
@@ -15,6 +15,7 @@ Test the next steps on:
 - On Android, tapping Enter to split a quote or pullquote citation both splits the block and adds a newline to the citation ([#2498](https://github.com/wordpress-mobile/gutenberg-mobile/issues/2498))
 - On Android, there is sometimes a loss of lines when entering multiple lines. ([#29861](https://github.com/WordPress/gutenberg/issues/29861))
 - On Android, the line spacing between the first two lines in the preformatted and verse blocks appear closer together in the editor than other lines. ([#38636](https://github.com/WordPress/gutenberg/issues/38636))
+- On Android, auto-correction of the first word in the Verse or Preformatted block leads to it being deleted. ([#52887](https://github.com/WordPress/gutenberg/issues/52887))
 - There is sometimes inconsistent HTML surrounding newlines in the Pullquote and Quote Block. ([#1396](https://github.com/wordpress-mobile/gutenberg-mobile/issues/1396))
 
 **New line on multiline components**


### PR DESCRIPTION
This PR adds the following issue to the known issues section of the multiline component test cases: https://github.com/WordPress/gutenberg/issues/52887