### PR TITLE
Remove migrated tests cases from functionality test suite 4

### DIFF
--- a/test-cases/gutenberg/darkmode.md
+++ b/test-cases/gutenberg/darkmode.md
@@ -38,30 +38,6 @@ Expected look:
 
 --------------------------------------------------------------------------------
 
-##### TC004
-
-### Spacer Block - Check if in DarkMode all components gets proper colors
-
--   Add a `Spacer` block
--   Check if `Spacer` block in Dark Mode looks like below
-
-Expected look:  
-![SpacerDarkMode](../resources/spacer-dark-mode.png)
-
---------------------------------------------------------------------------------
-
-##### TC005
-
-### Button Block - Check if in DarkMode all components gets proper colors
-
--   Add a `Button` block
--   Check if `Button` block in Dark Mode looks like below
-
-Expected look:  
-![ButtonDarkMode](../resources/button-dark-mode.png)
-
---------------------------------------------------------------------------------
-
 ##### TC008
 
 ### Quote Block - Check if in DarkMode all components gets proper colors

--- a/test-cases/gutenberg/group.md
+++ b/test-cases/gutenberg/group.md
@@ -79,58 +79,6 @@ Expected look:
 
 --------------------------------------------------------------------------------
 
-##### TC006
-
-### Navigation up button works as expected
-
--   Add a `Group` block
--   Create nested structure
--   Select deep nested block
--   Press navigation up button on `Breadcrumb`
--   Expect each time you press navigation up button the selection moves to parent block
--   Expect border changes accordingly
-
---------------------------------------------------------------------------------
-
-##### TC007
-
-### Navigation down works according to deepest-descendent-first approach
-
--   Add a `Group` block
--   Create some nested structure ( at least 3 levels deep )
--   Clear selection
--   Press on the bottom-most block in hierarchy of added `Group`
--   Check if the selection is redirect properly to depest descendant
-
---------------------------------------------------------------------------------
-
-##### TC008
-
-### Cross navigation between blocks works as expected
-
--   Add a `Group` block
--   Create some nested structure ( at least 3 levels deep )
--   Select nested block
--   Having nested block selected try to select block which is higher in the hierarchy (one, two and more levels above)
--   Check if that block gets selected after press
-
---------------------------------------------------------------------------------
-
-##### TC009
-
-### Check if in DarkMode all components gets proper colors
-
--   Add a `Group` block
--   Create nested structure
--   Switch to DarkMode
--   Check if all components switch it's color schema to dark
-
-Expected look:  
-![DarkMode](../resources/group-dark-mode.png)
-![DarkModeEmpty](../resources/group-dark-mode-empty.png)
-
---------------------------------------------------------------------------------
-
 ##### TC010
 
 ### Check if nested Placeholder block can be replaced

--- a/test-suites/gutenberg/functionality-test-suites.md
+++ b/test-suites/gutenberg/functionality-test-suites.md
@@ -175,7 +175,6 @@ This holds a grouping of certain test suites to run in order to share the work w
 
 ## Test Suite 4
 
-- DarkMode 2
 - Group 2
 - Buttons 4-5-7
 - Editor Theme 2
@@ -183,11 +182,6 @@ This holds a grouping of certain test suites to run in order to share the work w
 - VideoPress 1
 
 ```
-### DarkMode - 2
-
-- [ ] Spacer block - Dark mode - [TC004](https://github.com/wordpress-mobile/test-cases/blob/trunk/test-cases/gutenberg/darkmode.md#tc004)
-- [ ] Buttons block - Dark mode - [TC005](https://github.com/wordpress-mobile/test-cases/blob/trunk/test-cases/gutenberg/darkmode.md#tc005)
-
 ### Group - 2
 
 - [ ] Group - Navigation up button works as expected - [TC006](https://github.com/wordpress-mobile/test-cases/blob/trunk/test-cases/gutenberg/group.md#tc006)

--- a/test-suites/gutenberg/functionality-test-suites.md
+++ b/test-suites/gutenberg/functionality-test-suites.md
@@ -184,10 +184,6 @@ This holds a grouping of certain test suites to run in order to share the work w
 ```
 ### Group - 2
 
-- [ ] Group - Navigation up button works as expected - [TC006](https://github.com/wordpress-mobile/test-cases/blob/trunk/test-cases/gutenberg/group.md#tc006)
-- [ ] Group - Navigation down works according to parent-first approach - [TC007](https://github.com/wordpress-mobile/test-cases/blob/trunk/test-cases/gutenberg/group.md#tc007)
-- [ ] Group - Cross navigation between blocks works as expected - [TC008](https://github.com/wordpress-mobile/test-cases/blob/trunk/test-cases/gutenberg/group.md#tc008)
-- [ ] Group - Check if in DarkMode all components gets proper colors - [TC009](https://github.com/wordpress-mobile/test-cases/blob/trunk/test-cases/gutenberg/group.md#tc009)
 - [ ] Group - Check if nested Placeholder block can be replaced - [TC010](https://github.com/wordpress-mobile/test-cases/blob/trunk/test-cases/gutenberg/group.md#tc010)
 
 ### Buttons - 4

--- a/test-suites/gutenberg/functionality-tests.md
+++ b/test-suites/gutenberg/functionality-tests.md
@@ -45,11 +45,6 @@ DarkMode-1
 - [ ] Shortcode block - Dark mode - [steps](https://github.com/wordpress-mobile/test-cases/blob/trunk/test-cases/gutenberg/darkmode.md#tc002)
 - [ ] Media Text block - Dark mode - [steps](https://github.com/wordpress-mobile/test-cases/blob/trunk/test-cases/gutenberg/darkmode.md#tc003)
 
-DarkMode-2
-
-- [ ] Spacer block - Dark mode - [steps](https://github.com/wordpress-mobile/test-cases/blob/trunk/test-cases/gutenberg/darkmode.md#tc004)
-- [ ] Buttons block - Dark mode - [steps](https://github.com/wordpress-mobile/test-cases/blob/trunk/test-cases/gutenberg/darkmode.md#tc005)
-- [ ] Group - Dark mode - [steps](https://github.com/wordpress-mobile/test-cases/blob/trunk/test-cases/gutenberg/darkmode.md#tc009)
 
 Shortcode-1
 

--- a/test-suites/gutenberg/functionality-tests.md
+++ b/test-suites/gutenberg/functionality-tests.md
@@ -94,10 +94,6 @@ Group-1
 
 Group-2
 
-- [ ] Group - Navigation up button works as expected - [steps](https://github.com/wordpress-mobile/test-cases/blob/trunk/test-cases/gutenberg/group.md#tc006)
-- [ ] Group - Navigation down works according to parent-first approach - [steps](https://github.com/wordpress-mobile/test-cases/blob/trunk/test-cases/gutenberg/group.md#tc007)
-- [ ] Group - Cross navigation between blocks works as expected - [steps](https://github.com/wordpress-mobile/test-cases/blob/trunk/test-cases/gutenberg/group.md#tc008)
-- [ ] Group - Check if in DarkMode all components gets proper colors - [steps](https://github.com/wordpress-mobile/test-cases/blob/trunk/test-cases/gutenberg/group.md#tc009)
 - [ ] Group - Check if nested Placeholder block can be replaced - [steps](https://github.com/wordpress-mobile/test-cases/blob/trunk/test-cases/gutenberg/group.md#tc010)
 
 Cover-1


### PR DESCRIPTION
Following the changes from https://github.com/wordpress-mobile/gutenberg-mobile/pull/5977, we can remove the manual tests cases:

- Spacer block - Dark mode - [TC004](https://github.com/wordpress-mobile/test-cases/blob/trunk/test-cases/gutenberg/darkmode.md#tc004)
- Buttons block - Dark mode - [TC005](https://github.com/wordpress-mobile/test-cases/blob/trunk/test-cases/gutenberg/darkmode.md#tc005)
- Group - Navigation up button works as expected - [TC006](https://github.com/wordpress-mobile/test-cases/blob/trunk/test-cases/gutenberg/group.md#tc006)
- Group - Navigation down works according to parent-first approach - [TC007](https://github.com/wordpress-mobile/test-cases/blob/trunk/test-cases/gutenberg/group.md#tc007)
- Group - Cross navigation between blocks works as expected - [TC008](https://github.com/wordpress-mobile/test-cases/blob/trunk/test-cases/gutenberg/group.md#tc008)
- Group - Check if in DarkMode all components gets proper colors - [TC009](https://github.com/wordpress-mobile/test-cases/blob/trunk/test-cases/gutenberg/group.md#tc009)