### PR TITLE
Update unsupported-block-editing.md

### DIFF
--- a/test-cases/gutenberg/unsupported-block-editing.md
+++ b/test-cases/gutenberg/unsupported-block-editing.md
@@ -16,7 +16,7 @@
 ##### TC001
 
 **Known Issues**
--  **[iOS]** The app crashes in a simulator when running under certain network settings: [#21620](https://github.com/wordpress-mobile/WordPress-iOS/issues/21620).
+-  **[iOS]** The app fails to open the unsupported block for editing under certain local system conditions (crashes in debug mode, fails to open in release mode): [#21620](https://github.com/wordpress-mobile/WordPress-iOS/issues/21620).
 
 #### Precondition
 

--- a/test-cases/gutenberg/unsupported-block-editing.md
+++ b/test-cases/gutenberg/unsupported-block-editing.md
@@ -15,6 +15,9 @@
 
 ##### TC001
 
+**Known Issues**
+-  **[iOS]** The app crashes in a simulator when running under certain network settings: [#21620](https://github.com/wordpress-mobile/WordPress-iOS/issues/21620).
+
 #### Precondition
 
 A WP.com Simple site (i.e. not an Atomic site). Any free WP.com site should suffice.


### PR DESCRIPTION
Add the following issue found during testing https://github.com/wordpress-mobile/WordPress-iOS/issues/21620 to ensure we won't run into it again.