### PR TITLE
Add Keyboard expectations when splitting and merging blocks.

### DIFF
--- a/test-cases/gutenberg/writing-flow/splitting-merging.md
+++ b/test-cases/gutenberg/writing-flow/splitting-merging.md
@@ -23,10 +23,11 @@ Start from an empty post.
 
 **Merge after writing**
 - Follow the initial steps.
+- Expect the keyboard to not hide and show while splitting the blocks, it should be always visible.
 - Write some more text where the caret is placed (beginning of new block).
 - Delete all new text using the delete button until the blocks are merged again.
 - Check that the blocks were merged.
-
+- Expect the keyboard to not hide and show while merging the blocks, it should be always visible.
 
 ##### TC002
 
@@ -36,12 +37,13 @@ Start from an empty post.
 
 **Merge after selection**
 - Follow the initial steps.
+- Expect the keyboard to not hide and show while splitting the blocks, it should be always visible.
 - Write some more text where the caret is placed (beginning of new block)
 - Select all the newly written text,
 - Press delete to remove all selected text.
 - Press delete once again to merge the blocks.
 - Check that the blocks were merged.
-
+- Expect the keyboard to not hide and show while merging the blocks, it should be always visible.
 
 ##### TC003
 
@@ -51,10 +53,11 @@ Start from an empty post.
 
 **Merge after deleting text**
 - Follow the initial steps.
+- Expect the keyboard to not hide and show while splitting the blocks, it should be always visible.
 - Move the caret a few words.
 - Delete all those words until the blocks merge.
 - Check that the blocks were merged.
-
+- Expect the keyboard to not hide and show while merging the blocks, it should be always visible.
 
 ##### TC004
 
@@ -63,15 +66,19 @@ Start from an empty post.
 
 **Merge after deleting all**
 - Follow the initial steps.
+- Expect the keyboard to not hide and show while splitting the blocks, it should be always visible.
 - Select and remove all content of the new block
 - Press delete to remove the empty block.
 - Check that the previous block was selected.
-
+- Expect the keyboard to not hide and show while deleting and merging with the previous block, it should be always visible.
 
 ##### TC005
 
 **Merge multiple blocks**
 - Follow the initial steps.
-- Press enter two times to create an empty block in between 
+- Press enter two times to create an empty block in between.
+- Expect the keyboard to not hide and show while splitting the blocks, it should be always visible.
 - Press back two times to merge everything again.
 - Check that the blocks were merged.
+- Expect the keyboard to not hide and show while merging the blocks, it should be always visible.
+


### PR DESCRIPTION
This PR adds Keyboard visibility expectations when splitting and merging blocks, related to the recent changes to keep the keyboard always visible when changing the focus between text-based blocks.