### PR TITLE
Remove TC008 and TC009 cases of Audio block

### DIFF
--- a/test-cases/gutenberg/audio.md
+++ b/test-cases/gutenberg/audio.md
@@ -162,34 +162,6 @@ All test cases related to uploading audio files to the site require a plan that 
 - Full width: Audio block expands to the edges of the window.
 
 --------------------------------------------------------------------------------
-##### TC008
-
-**Autoplay setting**
-
-**Steps**
-
-- Press the Audio settings icon.
-- Switch ON the option for the Autoplay setting.
-
-**Expected Behavior**
-
-- On HTML mode there should be the `autoplay` attribute in the `<audio>` tag.
-
---------------------------------------------------------------------------------
-##### TC009
-
-**Loop setting**
-
-**Steps**
-
-- Press the Audio settings.
-- Switch ON the option for the Loop setting.
-
-**Expected Behavior**
-
-- On HTML mode there should be the `loop` attribute in the `<audio>` tag.
-
---------------------------------------------------------------------------------
 ##### TC010
 
 **Close/Re-open post with an ongoing audio file upload**

--- a/test-suites/gutenberg/functionality-test-suites.md
+++ b/test-suites/gutenberg/functionality-test-suites.md
@@ -254,8 +254,6 @@ Audio block - 3
 - [ ] Audio block - Change the alignment in the Audio Block - [TC007](https://github.com/wordpress-mobile/test-cases/blob/trunk/test-cases/gutenberg/audio.md#tc007)
 
 Audio block - 4
-- [ ] Audio block - Autoplay setting - [TC008](https://github.com/wordpress-mobile/test-cases/blob/trunk/test-cases/gutenberg/audio.md#tc008)
-- [ ] Audio block - Loop setting - [TC009](https://github.com/wordpress-mobile/test-cases/blob/trunk/test-cases/gutenberg/audio.md#tc009)
 - [ ] Audio block - Close/Re-open post with an ongoing audio file upload - [TC010](https://github.com/wordpress-mobile/test-cases/blob/trunk/test-cases/gutenberg/audio.md#tc010)
 
 Synced patterns - 1

--- a/test-suites/gutenberg/functionality-tests.md
+++ b/test-suites/gutenberg/functionality-tests.md
@@ -172,8 +172,6 @@ Audio block - 3
 - [ ] Audio block - Change the alignment in the Audio Block - [steps](https://github.com/wordpress-mobile/test-cases/blob/trunk/test-cases/gutenberg/audio.md#tc007)
 
 Audio block - 4
-- [ ] Audio block - Autoplay setting - [steps](https://github.com/wordpress-mobile/test-cases/blob/trunk/test-cases/gutenberg/audio.md#tc008)
-- [ ] Audio block - Loop setting - [steps](https://github.com/wordpress-mobile/test-cases/blob/trunk/test-cases/gutenberg/audio.md#tc009)
 - [ ] Audio block - Close/Re-open post with an ongoing audio file upload - [steps](https://github.com/wordpress-mobile/test-cases/blob/trunk/test-cases/gutenberg/audio.md#tc010)
 
 Synced patterns - 1


### PR DESCRIPTION
In https://github.com/WordPress/gutenberg/pull/57715, test cases TC008 and TC009 of Audio block will be automated, so we can remove them.