### PR TITLE
Add separator between test cases

### DIFF
--- a/test-cases/gutenberg/media-text.md
+++ b/test-cases/gutenberg/media-text.md
@@ -1,9 +1,13 @@
 
 # Media-Text Block - Test Cases
 
+--------------------------------------------------------------------------------
+
 #### **Precondition**
 
 A site with premium or business plan
+
+--------------------------------------------------------------------------------
 
 ##### TC001-i
 
@@ -11,11 +15,15 @@ A site with premium or business plan
 
 Use same same steps on Media-Text block: [image block TC001](https://github.com/wordpress-mobile/test-cases/blob/master/test-cases/gutenberg/image.md#tc001).
 
+--------------------------------------------------------------------------------
+
 ##### TC001-v
 
 **Insert video from device (failing)**
 
 Use same same steps on Media-Text block: [video block TC001](https://github.com/wordpress-mobile/test-cases/blob/master/test-cases/gutenberg/video.md#tc001).
+
+--------------------------------------------------------------------------------
 
 ##### TC002-i
 
@@ -23,11 +31,15 @@ Use same same steps on Media-Text block: [video block TC001](https://github.com/
 
 Use same same steps on Media-Text block: [image block TC002](https://github.com/wordpress-mobile/test-cases/blob/master/test-cases/gutenberg/image.md#tc002) 
 
+--------------------------------------------------------------------------------
+
 ##### TC002-v
 
 **Insert video from device (cancel)**
 
 Use same same steps on Media-Text block: [video block TC002](https://github.com/wordpress-mobile/test-cases/blob/master/test-cases/gutenberg/video.md#tc002) 
+
+--------------------------------------------------------------------------------
 
 ##### TC003-i
 
@@ -35,11 +47,15 @@ Use same same steps on Media-Text block: [video block TC002](https://github.com/
 
 Use same same steps on Media-Text block: [image block TC004](https://github.com/wordpress-mobile/test-cases/blob/master/test-cases/gutenberg/image.md#tc004)
 
+--------------------------------------------------------------------------------
+
 ##### TC003-v
 
 **Close/Re-open post with an ongoing video upload**
 
 Use same same steps on Media-Text block: [video block TC004](https://github.com/wordpress-mobile/test-cases/blob/master/test-cases/gutenberg/video.md#tc004)
+
+--------------------------------------------------------------------------------
 
 ##### TC004-i
 
@@ -47,11 +63,15 @@ Use same same steps on Media-Text block: [video block TC004](https://github.com/
 
 Use same same steps on Media-Text block: [image block TC005](https://github.com/wordpress-mobile/test-cases/blob/master/test-cases/gutenberg/image.md#tc005) 
 
+--------------------------------------------------------------------------------
+
 ##### TC004-v
 
 **Close post with an ongoing video upload**
 
 Use same same steps on Media-Text block: [video block TC005](https://github.com/wordpress-mobile/test-cases/blob/master/test-cases/gutenberg/video.md#tc005)
+
+--------------------------------------------------------------------------------
 
 ##### TC005-i
 

--- a/test-cases/gutenberg/unsupported-block-editing.md
+++ b/test-cases/gutenberg/unsupported-block-editing.md
@@ -33,6 +33,7 @@ A WP.com Simple site (i.e. not an Atomic site). Any free WP.com site should suff
 7. Tap the Continue button and expect to be taken back to the block editor
 8. Publish the post and verify it contains the edits
 
+--------------------------------------------------------------------------------
 
 ##### TC002
 
@@ -46,6 +47,7 @@ A WP.com Simple site (i.e. not an Atomic site). Any free WP.com site should suff
 3. Expect the Update button to be greyed-out
 4. Using HTML mode in the editor, view the HTML content of the post and expect it to **not** contain any of the edits
 
+--------------------------------------------------------------------------------
 
 ##### TC003
 
@@ -67,6 +69,7 @@ A WP.com Atomic site (i.e. a WP.com site with a Business plan) with the **Gutenb
 7. Tap the Continue button and expect to be taken back to the block editor
 8. Publish the post and verify it contains the edits
 
+--------------------------------------------------------------------------------
 
 ##### TC004
 
@@ -87,6 +90,7 @@ A WP.com Atomic site (i.e. a WP.com site with a Business plan) with the **Classi
 4. Tap the edit in a web browser button and expect to see loading screen
 5. After a while (~10 seconds) expect to see the `Unable to load the block editor right now` screen.
 
+--------------------------------------------------------------------------------
 
 ##### TC005
 
@@ -112,6 +116,7 @@ For this test, you need a self-hosted site with the Jetpack plugin installed, ac
 8. Tap the Continue button and expect to be taken back to the block editor
 9. Publish the post and verify it contains the edits
 
+--------------------------------------------------------------------------------
 
 ##### TC006
 

--- a/test-cases/gutenberg/video.md
+++ b/test-cases/gutenberg/video.md
@@ -1,9 +1,13 @@
 
 # Video Block - Test Cases
 
+--------------------------------------------------------------------------------
+
 #### **Precondition**
 
 A site with premium or business plan
+
+--------------------------------------------------------------------------------
 
 ##### TC001
 
@@ -13,17 +17,23 @@ Steps are same with [image block TC001](https://github.com/wordpress-mobile/test
 
 ![Upload failed](../resources/video-upload-failed.png)
 
+--------------------------------------------------------------------------------
+
 ##### TC002
 
 **Insert video from device (cancel)**
 
 Same with [image block TC002](https://github.com/wordpress-mobile/test-cases/blob/master/test-cases/gutenberg/image.md#tc002) 
 
+--------------------------------------------------------------------------------
+
 ##### TC003
 
 **Add Caption**
 
 Same with [image block TC003](https://github.com/wordpress-mobile/test-cases/blob/master/test-cases/gutenberg/image.md#tc003)
+
+--------------------------------------------------------------------------------
 
 ##### TC004
 
@@ -32,6 +42,8 @@ Same with [image block TC003](https://github.com/wordpress-mobile/test-cases/blo
 Steps are same with [image block TC004](https://github.com/wordpress-mobile/test-cases/blob/master/test-cases/gutenberg/image.md#tc004) except for the difference in UI:
 
 ![Upload progress](../resources/upload-progress-video.png)
+
+--------------------------------------------------------------------------------
 
 ##### TC005
 

--- a/test-cases/gutenberg/writing-flow/splitting-merging.md
+++ b/test-cases/gutenberg/writing-flow/splitting-merging.md
@@ -3,6 +3,8 @@
 **Known Issues**
 - **[Android]** Splitting block before "swiped" word loses "swiped" word https://github.com/wordpress-mobile/gutenberg-mobile/issues/2373
 
+--------------------------------------------------------------------------------
+
 #### **Precondition**
 
 Start from an empty post.
@@ -14,6 +16,7 @@ Start from an empty post.
 - Set the caret by the half of the paragraph
 - Press Enter (Intro) to split the block into two.
 
+--------------------------------------------------------------------------------
 
 ##### TC001
 
@@ -28,6 +31,8 @@ Start from an empty post.
 - Delete all new text using the delete button until the blocks are merged again.
 - Check that the blocks were merged.
 - Expect the keyboard to not hide and show while merging the blocks, it should be always visible.
+
+--------------------------------------------------------------------------------
 
 ##### TC002
 
@@ -45,6 +50,8 @@ Start from an empty post.
 - Check that the blocks were merged.
 - Expect the keyboard to not hide and show while merging the blocks, it should be always visible.
 
+--------------------------------------------------------------------------------
+
 ##### TC003
 
 **Known Issues**
@@ -59,6 +66,8 @@ Start from an empty post.
 - Check that the blocks were merged.
 - Expect the keyboard to not hide and show while merging the blocks, it should be always visible.
 
+--------------------------------------------------------------------------------
+
 ##### TC004
 
 **Known Issues**
@@ -71,6 +80,8 @@ Start from an empty post.
 - Press delete to remove the empty block.
 - Check that the previous block was selected.
 - Expect the keyboard to not hide and show while deleting and merging with the previous block, it should be always visible.
+
+--------------------------------------------------------------------------------
 
 ##### TC005
 

--- a/test-cases/jetpack/story.md
+++ b/test-cases/jetpack/story.md
@@ -14,6 +14,7 @@ A wordpress.com site or a jetpack site with jetpack version 9.1 or newer
 2. Verify the Story block appears among the blocks that can be added to the Post, and add it
 3. An empty Story block should have been added to the Post (with the Add Media placeholder)
 
+--------------------------------------------------------------------------------
 
 ##### TC002
 
@@ -61,6 +62,7 @@ A wordpress.com site or a jetpack site with jetpack version 9.1 or newer
 
 For reference, see https://github.com/wordpress-mobile/WordPress-Android/pull/13174
 
+--------------------------------------------------------------------------------
 
 ##### TC004
 
@@ -76,6 +78,7 @@ For reference, see https://github.com/wordpress-mobile/WordPress-Android/pull/13
 
 (*) known issue: the image will flash as it shows the local file first, and then changes to point to the remote url after upload finishes, showing a blank cover for a few moments while the remote URL is loaded
 
+--------------------------------------------------------------------------------
 
 ##### TC005
 

--- a/test-cases/jetpack/videopress.md
+++ b/test-cases/jetpack/videopress.md
@@ -1,9 +1,13 @@
 
 # VideoPress Block - Test Cases
 
+--------------------------------------------------------------------------------
+
 #### **Precondition**
 
 Use Simple WordPress.com site with a Premium plan. Free or Personal plans only allow upload videos that are less than five minutes in length or a video size smaller than 100 MB.
+
+--------------------------------------------------------------------------------
 
 ##### TC001
 
@@ -52,6 +56,8 @@ Use Simple WordPress.com site with a Premium plan. Free or Personal plans only a
 
 <img src="../../test-cases/resources/../resources/videopress-player-2.png" width="260">
 
+--------------------------------------------------------------------------------
+
 ##### TC004
 
 **Close post with an ongoing video upload**
@@ -66,6 +72,8 @@ Use Simple WordPress.com site with a Premium plan. Free or Personal plans only a
 - Wait for the upload to complete while in the post list.
 - Re-open the post with the VideoPres block.
 - Observe that the video is displayed within the block.
+
+--------------------------------------------------------------------------------
 
 ##### TC005
 
@@ -85,6 +93,8 @@ Use Simple WordPress.com site with a Premium plan. Free or Personal plans only a
 - Observe the video can't be played.
 
 <img src="../../test-cases/resources/../resources/videopress-private-video-1.png" width="360">
+
+--------------------------------------------------------------------------------
 
 ##### TC006
 


### PR DESCRIPTION
Following https://github.com/wordpress-mobile/test-cases/pull/162#pullrequestreview-1821263956, this PR applies the same formatting for the rest of the files. Specifically, it adds a separator between test cases.