### PR TITLE
Remove Highlight text test case

### DIFF
--- a/test-cases/gutenberg/writing-flow/rich-text-formatting.md
+++ b/test-cases/gutenberg/writing-flow/rich-text-formatting.md
@@ -9,20 +9,6 @@ Have a rich-text based component with content (Paragraph, Heading, Quote, Media 
 
 --------------------------------------------------------------------------------
 
-##### TC001
-
-**Known Issues**
-
-- [Text color selection is not preserved when cursor is placed in the middle of text](https://github.com/WordPress/gutenberg/issues/42714)
-
-### Highlight text without selection
-
-- Without selecting any text tap on the highlight text button (Drop icon) located in the formatting toolbar.
-- Select a color and write some text.
-- Expect to see the newly introduced text with the previously selected color.
-
---------------------------------------------------------------------------------
-
 ##### TC007
 
 ### Test format detection under the cursor


### PR DESCRIPTION
We have some integration tests and we are introducing a visual E2E test in https://github.com/wordpress-mobile/gutenberg-mobile/pull/6517

The known issue was fixed as well.